### PR TITLE
Get tests running again, using JUnit 5.

### DIFF
--- a/org.librarysimplified.audiobook.tests.device/build.gradle
+++ b/org.librarysimplified.audiobook.tests.device/build.gradle
@@ -1,3 +1,10 @@
+android {
+  packagingOptions {
+    exclude "META-INF/LICENSE.md"
+    exclude "META-INF/LICENSE-notice.md"
+  }
+}
+
 dependencies {
   androidTestImplementation libs.androidx.app.compat
   androidTestImplementation libs.androidx.test.espresso

--- a/org.librarysimplified.audiobook.tests/build.gradle
+++ b/org.librarysimplified.audiobook.tests/build.gradle
@@ -15,16 +15,16 @@ dependencies {
   api project(':org.librarysimplified.audiobook.rbdigital')
   api project(':org.librarysimplified.audiobook.views')
 
-  api libs.junit
   api libs.kotlin.stdlib
-  api libs.mockito
   api libs.okhttp3
   api libs.quicktheories
   api libs.slf4j
 
+  implementation libs.junit.jupiter.api
+  implementation libs.junit.jupiter.engine
+  implementation libs.mockito.kotlin
+
   testImplementation libs.logback.classic
-  testImplementation libs.junit.jupiter.api
-  testImplementation libs.junit.jupiter.engine
 }
 
 /*

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksExtensionContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksExtensionContract.kt
@@ -4,10 +4,10 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
-import org.junit.After
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
 import org.librarysimplified.audiobook.api.PlayerDownloadRequest
 import org.librarysimplified.audiobook.api.PlayerDownloadRequestCredentials
@@ -31,7 +31,7 @@ abstract class FeedbooksExtensionContract {
   private lateinit var downloadProvider: FakeDownloadProvider
   private lateinit var executor: ListeningExecutorService
 
-  @Before
+  @BeforeEach
   fun testSetup() {
     this.executor =
       MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
@@ -51,7 +51,7 @@ abstract class FeedbooksExtensionContract {
     }
   }
 
-  @After
+  @AfterEach
   fun testTearDown() {
     this.executor.shutdown()
   }
@@ -86,7 +86,7 @@ abstract class FeedbooksExtensionContract {
         )
       )
 
-    Assert.assertEquals(null, future)
+    Assertions.assertEquals(null, future)
   }
 
   /**
@@ -129,11 +129,11 @@ abstract class FeedbooksExtensionContract {
       future!!.get()
     } catch (e: ExecutionException) {
       val cause = e.cause as IllegalStateException
-      Assert.assertTrue(cause.message!!.contains("has not been configured"))
+      Assertions.assertTrue(cause.message!!.contains("has not been configured"))
       return
     }
 
-    Assert.fail()
+    Assertions.fail<Any>()
   }
 
   /**
@@ -180,8 +180,8 @@ abstract class FeedbooksExtensionContract {
     future!!.get()
 
     val sentRequest = this.downloadProvider.requests.poll()
-    Assert.assertEquals(request.uri, sentRequest.uri)
-    Assert.assertEquals(request.outputFile, sentRequest.outputFile)
-    Assert.assertTrue(sentRequest.credentials is PlayerDownloadRequestCredentials.BearerToken)
+    Assertions.assertEquals(request.uri, sentRequest.uri)
+    Assertions.assertEquals(request.outputFile, sentRequest.outputFile)
+    Assertions.assertTrue(sentRequest.credentials is PlayerDownloadRequestCredentials.BearerToken)
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksRightsCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksRightsCheckContract.kt
@@ -1,11 +1,10 @@
 package org.librarysimplified.audiobook.tests
 
 import org.joda.time.LocalDateTime
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.feedbooks.FeedbooksRightsCheck
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
@@ -16,6 +15,7 @@ import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
 import org.librarysimplified.audiobook.manifest_parser.extension_spi.ManifestParserExtensionType
 import org.librarysimplified.audiobook.parser.api.ParseResult
 import org.slf4j.Logger
+import java.io.File
 import java.net.URI
 import java.util.ServiceLoader
 
@@ -25,11 +25,11 @@ abstract class FeedbooksRightsCheckContract {
 
   abstract fun log(): Logger
 
-  @Rule
+  @TempDir
   @JvmField
-  val tempFolder = TemporaryFolder()
+  val tempFolder: File? = null
 
-  @Before
+  @BeforeEach
   fun testSetup() {
     this.eventLog = mutableListOf()
   }
@@ -44,12 +44,12 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.now()
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.NotApplicable)
+    Assertions.assertTrue(result is SingleLicenseCheckResult.NotApplicable)
   }
 
   @Test
@@ -62,12 +62,12 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Succeeded)
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Succeeded)
   }
 
   @Test
@@ -80,13 +80,13 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.parse("1999-01-01T00:10:00.000")
       ).execute()
 
     val failed = result as SingleLicenseCheckResult.Failed
-    Assert.assertTrue(failed.message.contains("precedes"))
+    Assertions.assertTrue(failed.message.contains("precedes"))
   }
 
   @Test
@@ -99,13 +99,13 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.parse("2002-01-01T00:10:00.000")
       ).execute()
 
     val failed = result as SingleLicenseCheckResult.Failed
-    Assert.assertTrue(failed.message.contains("exceeds"))
+    Assertions.assertTrue(failed.message.contains("exceeds"))
   }
 
   @Test
@@ -118,12 +118,12 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Succeeded)
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Succeeded)
   }
 
   @Test
@@ -136,12 +136,12 @@ abstract class FeedbooksRightsCheckContract {
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
           onStatusChanged = { },
-          cacheDirectory = tempFolder.newFolder("cache")
+          cacheDirectory = File(tempFolder, "cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Succeeded)
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Succeeded)
   }
 
   private fun manifest(
@@ -154,7 +154,7 @@ abstract class FeedbooksRightsCheckContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    Assert.assertTrue("Result is success", result is ParseResult.Success)
+    Assertions.assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksSignatureCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksSignatureCheckContract.kt
@@ -6,11 +6,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.feedbooks.FeedbooksSignatureCheck
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
@@ -31,11 +30,11 @@ abstract class FeedbooksSignatureCheckContract {
 
   abstract fun log(): Logger
 
-  @Rule
+  @TempDir
   @JvmField
-  val tempFolder = TemporaryFolder()
+  val tempFolder: File? = null
 
-  @Before
+  @BeforeEach
   fun testSetup() {
     this.eventLog = mutableListOf()
   }
@@ -66,7 +65,7 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Succeeded)
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Succeeded)
   }
 
   /**
@@ -91,8 +90,8 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Failed)
-    Assert.assertTrue(result.message.contains("not verified", true))
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Failed)
+    Assertions.assertTrue(result.message.contains("not verified", true))
   }
 
   /**
@@ -117,8 +116,8 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Failed)
-    Assert.assertTrue(result.message.contains("unsupported signature algorithm", true))
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Failed)
+    Assertions.assertTrue(result.message.contains("unsupported signature algorithm", true))
   }
 
   /**
@@ -143,8 +142,8 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Failed)
-    Assert.assertTrue(result.message.contains("unknown signature issuer", true))
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Failed)
+    Assertions.assertTrue(result.message.contains("unknown signature issuer", true))
   }
 
   /**
@@ -165,8 +164,8 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Failed)
-    Assert.assertTrue(result.message.contains("could not be retrieved", true))
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Failed)
+    Assertions.assertTrue(result.message.contains("could not be retrieved", true))
   }
 
   /**
@@ -195,8 +194,8 @@ abstract class FeedbooksSignatureCheckContract {
         )
       ).execute()
 
-    Assert.assertTrue(result is SingleLicenseCheckResult.Failed)
-    Assert.assertTrue(result.message.contains("could not be parsed", true))
+    Assertions.assertTrue(result is SingleLicenseCheckResult.Failed)
+    Assertions.assertTrue(result.message.contains("could not be parsed", true))
   }
 
   private fun manifest(
@@ -209,7 +208,7 @@ abstract class FeedbooksSignatureCheckContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    Assert.assertTrue("Result is success", result is ParseResult.Success)
+    Assertions.assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -285,6 +284,6 @@ abstract class FeedbooksSignatureCheckContract {
   }
 
   private fun emptyCacheDirectory(): File {
-    return tempFolder.newFolder("cache")
+    return File(tempFolder, "cache")
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JOSEHeaderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JOSEHeaderContract.kt
@@ -1,7 +1,8 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import org.librarysimplified.audiobook.json_web_token.JOSEHeader
 import org.librarysimplified.audiobook.parser.api.ParseResult
 import org.quicktheories.QuickTheory
@@ -25,7 +26,7 @@ abstract class JOSEHeaderContract {
       ) as ParseResult.Success
 
     val token = result.result
-    Assert.assertEquals(0, token.headers.size)
+    Assertions.assertEquals(0, token.headers.size)
   }
 
   /**
@@ -45,16 +46,17 @@ abstract class JOSEHeaderContract {
       ) as ParseResult.Success
 
     val token = result.result
-    Assert.assertEquals(2, token.headers.size)
-    Assert.assertEquals("JWT", token.headers["typ"])
-    Assert.assertEquals("HS256", token.headers["alg"])
+    Assertions.assertEquals(2, token.headers.size)
+    Assertions.assertEquals("JWT", token.headers["typ"])
+    Assertions.assertEquals("HS256", token.headers["alg"])
   }
 
   /**
    * Encoding and decoding are inverses of each other.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testIdentity() {
     val theory =
       QuickTheory.qt()

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONBase64StringTest.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONBase64StringTest.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.json_web_token.JSONBase64String
 import java.security.SecureRandom
 
@@ -15,6 +15,6 @@ class JSONBase64StringTest {
 
     val encoded = JSONBase64String.encode(decoded)
     val decodedAfter = encoded.decode()
-    Assert.assertArrayEquals(decodedAfter, decoded)
+    Assertions.assertArrayEquals(decodedAfter, decoded)
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONWebSignatureContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONWebSignatureContract.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import org.librarysimplified.audiobook.json_web_token.JOSEHeader
 import org.librarysimplified.audiobook.json_web_token.JSONWebSignature
 import org.librarysimplified.audiobook.json_web_token.JSONWebSignatureAlgorithmHMACSha256
@@ -16,7 +17,8 @@ abstract class JSONWebSignatureContract {
    * Signing produces a verifiable signature.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testVerification() {
     val theory =
       QuickTheory.qt()

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONWebTokenClaimsContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/JSONWebTokenClaimsContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.json_web_token.JSONWebTokenClaims
 import org.librarysimplified.audiobook.parser.api.ParseResult
 import org.quicktheories.QuickTheory
@@ -25,7 +25,7 @@ abstract class JSONWebTokenClaimsContract {
       ) as ParseResult.Success
 
     val token = result.result
-    Assert.assertEquals(0, token.claims.size)
+    Assertions.assertEquals(0, token.claims.size)
   }
 
   /**
@@ -45,9 +45,9 @@ abstract class JSONWebTokenClaimsContract {
       ) as ParseResult.Success
 
     val token = result.result
-    Assert.assertEquals(2, token.claims.size)
-    Assert.assertEquals("JWT", token.claims["typ"])
-    Assert.assertEquals("HS256", token.claims["alg"])
+    Assertions.assertEquals(2, token.claims.size)
+    Assertions.assertEquals("JWT", token.claims["typ"])
+    Assertions.assertEquals("HS256", token.claims["alg"])
   }
 
   /**

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseCheckContract.kt
@@ -1,10 +1,9 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.license_check.api.LicenseCheckParameters
 import org.librarysimplified.audiobook.license_check.api.LicenseCheckProviderType
@@ -18,6 +17,7 @@ import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
 import org.librarysimplified.audiobook.manifest_parser.extension_spi.ManifestParserExtensionType
 import org.librarysimplified.audiobook.parser.api.ParseResult
 import org.slf4j.Logger
+import java.io.File
 import java.io.IOException
 import java.net.URI
 import java.util.ServiceLoader
@@ -30,11 +30,11 @@ abstract class LicenseCheckContract {
 
   abstract fun licenseChecks(): LicenseCheckProviderType
 
-  @Rule
+  @TempDir
   @JvmField
-  val tempFolder = TemporaryFolder()
+  val tempFolder: File? = null
 
-  @Before
+  @BeforeEach
   fun testSetup() {
     this.eventLog = mutableListOf()
   }
@@ -53,7 +53,7 @@ abstract class LicenseCheckContract {
         manifest = manifest,
         userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
         checks = listOf(),
-        cacheDirectory = tempFolder.newFolder("cache")
+        cacheDirectory = File(tempFolder,"cache")
       )
 
     val result =
@@ -62,8 +62,8 @@ abstract class LicenseCheckContract {
         check.execute()
       }
 
-    Assert.assertEquals(0, result.checkStatuses.size)
-    Assert.assertTrue(result.checkSucceeded())
+    Assertions.assertEquals(0, result.checkStatuses.size)
+    Assertions.assertTrue(result.checkSucceeded())
   }
 
   /**
@@ -85,7 +85,7 @@ abstract class LicenseCheckContract {
           FailingTest(),
           SucceedingTest()
         ),
-        cacheDirectory = tempFolder.newFolder("cache")
+        cacheDirectory = File(tempFolder,"cache")
       )
 
     val result =
@@ -94,8 +94,8 @@ abstract class LicenseCheckContract {
         check.execute()
       }
 
-    Assert.assertEquals(4, result.checkStatuses.size)
-    Assert.assertFalse(result.checkSucceeded())
+    Assertions.assertEquals(4, result.checkStatuses.size)
+    Assertions.assertFalse(result.checkSucceeded())
   }
 
   /**
@@ -117,7 +117,7 @@ abstract class LicenseCheckContract {
           CrashingTest(),
           SucceedingTest()
         ),
-        cacheDirectory = tempFolder.newFolder("cache")
+        cacheDirectory = File(tempFolder,"cache")
       )
 
     val result =
@@ -126,8 +126,8 @@ abstract class LicenseCheckContract {
         check.execute()
       }
 
-    Assert.assertEquals(4, result.checkStatuses.size)
-    Assert.assertFalse(result.checkSucceeded())
+    Assertions.assertEquals(4, result.checkStatuses.size)
+    Assertions.assertFalse(result.checkSucceeded())
   }
 
   /**
@@ -149,7 +149,7 @@ abstract class LicenseCheckContract {
           NonApplicableTest(),
           NonApplicableTest()
         ),
-        cacheDirectory = tempFolder.newFolder("cache")
+        cacheDirectory = File(tempFolder,"cache")
       )
 
     val result =
@@ -158,8 +158,8 @@ abstract class LicenseCheckContract {
         check.execute()
       }
 
-    Assert.assertEquals(4, result.checkStatuses.size)
-    Assert.assertTrue(result.checkSucceeded())
+    Assertions.assertEquals(4, result.checkStatuses.size)
+    Assertions.assertTrue(result.checkSucceeded())
   }
 
   private class NonApplicableTest : SingleLicenseCheckType, SingleLicenseCheckProviderType {
@@ -232,7 +232,7 @@ abstract class LicenseCheckContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    Assert.assertTrue("Result is success", result is ParseResult.Success)
+    Assertions.assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseStatusParserContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseStatusParserContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.lcp.license_status.LicenseStatusDocument
 import org.librarysimplified.audiobook.lcp.license_status.LicenseStatusParserProviderType
 import org.librarysimplified.audiobook.parser.api.ParseResult
@@ -21,7 +21,7 @@ abstract class LicenseStatusParserContract {
       parser.parse() as ParseResult.Success
 
     val document = result.result
-    Assert.assertEquals(LicenseStatusDocument.Status.ACTIVE, document.status)
+    Assertions.assertEquals(LicenseStatusDocument.Status.ACTIVE, document.status)
   }
 
   @Test
@@ -34,7 +34,7 @@ abstract class LicenseStatusParserContract {
       parser.parse() as ParseResult.Success
 
     val document = result.result
-    Assert.assertEquals(LicenseStatusDocument.Status.ACTIVE, document.status)
+    Assertions.assertEquals(LicenseStatusDocument.Status.ACTIVE, document.status)
   }
 
   @Test
@@ -47,7 +47,7 @@ abstract class LicenseStatusParserContract {
       parser.parse() as ParseResult.Success
 
     val document = result.result
-    Assert.assertEquals(LicenseStatusDocument.Status.REVOKED, document.status)
+    Assertions.assertEquals(LicenseStatusDocument.Status.REVOKED, document.status)
   }
 
   private fun resource(

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentBasicContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentBasicContract.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.tests
 
+import com.nhaarman.mockitokotlin2.any
 import okhttp3.Call
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -7,9 +8,9 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.manifest_fulfill.basic.ManifestFulfillmentBasicCredentials
@@ -24,7 +25,7 @@ abstract class ManifestFulfillmentBasicContract {
   private lateinit var call: Call
   private lateinit var client: OkHttpClient
 
-  @Before
+  @BeforeEach
   fun testSetup() {
     this.client =
       Mockito.mock(OkHttpClient::class.java)
@@ -50,7 +51,7 @@ abstract class ManifestFulfillmentBasicContract {
         )
         .build()
 
-    Mockito.`when`(this.client.newCall(Mockito.any()))
+    Mockito.`when`(this.client.newCall(any()))
       .thenReturn(this.call)
     Mockito.`when`(this.call.execute())
       .thenReturn(response)
@@ -77,10 +78,10 @@ abstract class ManifestFulfillmentBasicContract {
 
     val error = result.failure
     val serverData = error.serverData!!
-    Assert.assertEquals(404, serverData.code)
-    Assert.assertEquals("NOT FOUND", error.message)
-    Assert.assertArrayEquals(ByteArray(0), serverData.receivedBody)
-    Assert.assertEquals("application/octet-stream", serverData.receivedContentType)
+    Assertions.assertEquals(404, serverData.code)
+    Assertions.assertEquals("NOT FOUND", error.message)
+    Assertions.assertArrayEquals(ByteArray(0), serverData.receivedBody)
+    Assertions.assertEquals("application/octet-stream", serverData.receivedContentType)
   }
 
   /**
@@ -107,7 +108,7 @@ abstract class ManifestFulfillmentBasicContract {
         )
         .build()
 
-    Mockito.`when`(this.client.newCall(Mockito.any()))
+    Mockito.`when`(this.client.newCall(any()))
       .thenReturn(this.call)
     Mockito.`when`(this.call.execute())
       .thenReturn(response)
@@ -133,6 +134,6 @@ abstract class ManifestFulfillmentBasicContract {
       strategy.execute() as PlayerResult.Success
 
     val data = result.result
-    Assert.assertEquals("Some text.", String(data.data))
+    Assertions.assertEquals("Some text.", String(data.data))
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentStrategiesContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentStrategiesContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.manifest_fulfill.api.ManifestFulfillmentStrategies
 import org.librarysimplified.audiobook.manifest_fulfill.basic.ManifestFulfillmentBasicType
 import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentStrategyProviderType
@@ -12,13 +12,13 @@ abstract class ManifestFulfillmentStrategiesContract {
   fun testBasic0() {
     val strategy =
       ManifestFulfillmentStrategies.findStrategy(ManifestFulfillmentBasicType::class.java)
-    Assert.assertNotNull(strategy)
+    Assertions.assertNotNull(strategy)
   }
 
   @Test
   fun testBasic1() {
     val strategy =
       ManifestFulfillmentStrategies.findStrategy(ManifestFulfillmentStrategyProviderType::class.java)
-    Assert.assertNotNull(strategy)
+    Assertions.assertNotNull(strategy)
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerAudioEnginesContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerAudioEnginesContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
 import org.librarysimplified.audiobook.api.PlayerAudioEngines
 import org.librarysimplified.audiobook.api.PlayerUserAgent
@@ -29,7 +29,7 @@ abstract class PlayerAudioEnginesContract {
       userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
     )
     val providers = PlayerAudioEngines.findAllFor(request)
-    Assert.assertEquals("Exactly one open access provider should be present", 1, providers.size)
+    Assertions.assertEquals(1, providers.size, "Exactly one open access provider should be present")
   }
 
   @Test
@@ -42,7 +42,7 @@ abstract class PlayerAudioEnginesContract {
       userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
     )
     val providers = PlayerAudioEngines.findAllFor(request)
-    Assert.assertEquals("No providers should be present", 0, providers.size)
+    Assertions.assertEquals(0, providers.size, "No providers should be present")
   }
 
   private fun parseManifest(file: String): PlayerManifest {
@@ -54,7 +54,7 @@ abstract class PlayerAudioEnginesContract {
       )
 
     this.log().debug("result: {}", result)
-    Assert.assertTrue("Result is success", result is ParseResult.Success)
+    Assertions.assertTrue(result is ParseResult.Success, "Result is success")
     val manifest = (result as ParseResult.Success).result
     return manifest
   }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
@@ -1,8 +1,8 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.feedbooks.FeedbooksRights
 import org.librarysimplified.audiobook.feedbooks.FeedbooksSignature
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
@@ -31,7 +31,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is failure", result is ParseResult.Failure)
+    assertTrue(result is ParseResult.Failure, "Result is failure")
   }
 
   @Test
@@ -43,7 +43,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is failure", result is ParseResult.Failure)
+    assertTrue(result is ParseResult.Failure, "Result is failure")
   }
 
   @Test
@@ -55,7 +55,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -73,7 +73,7 @@ abstract class PlayerManifestContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -83,24 +83,24 @@ abstract class PlayerManifestContract {
   }
 
   private fun checkMinimalValues(manifest: PlayerManifest) {
-    Assert.assertEquals(3, manifest.readingOrder.size)
-    Assert.assertEquals("Track 0", manifest.readingOrder[0].title.toString())
-    Assert.assertEquals("100.0", manifest.readingOrder[0].duration.toString())
-    Assert.assertEquals("audio/mpeg", manifest.readingOrder[0].type.toString())
-    Assert.assertEquals("http://www.example.com/0.mp3", manifest.readingOrder[0].hrefURI.toString())
+    Assertions.assertEquals(3, manifest.readingOrder.size)
+    Assertions.assertEquals("Track 0", manifest.readingOrder[0].title.toString())
+    Assertions.assertEquals("100.0", manifest.readingOrder[0].duration.toString())
+    Assertions.assertEquals("audio/mpeg", manifest.readingOrder[0].type.toString())
+    Assertions.assertEquals("http://www.example.com/0.mp3", manifest.readingOrder[0].hrefURI.toString())
 
-    Assert.assertEquals("Track 1", manifest.readingOrder[1].title.toString())
-    Assert.assertEquals("200.0", manifest.readingOrder[1].duration.toString())
-    Assert.assertEquals("audio/mpeg", manifest.readingOrder[1].type.toString())
-    Assert.assertEquals("http://www.example.com/1.mp3", manifest.readingOrder[1].hrefURI.toString())
+    Assertions.assertEquals("Track 1", manifest.readingOrder[1].title.toString())
+    Assertions.assertEquals("200.0", manifest.readingOrder[1].duration.toString())
+    Assertions.assertEquals("audio/mpeg", manifest.readingOrder[1].type.toString())
+    Assertions.assertEquals("http://www.example.com/1.mp3", manifest.readingOrder[1].hrefURI.toString())
 
-    Assert.assertEquals("Track 2", manifest.readingOrder[2].title.toString())
-    Assert.assertEquals("300.0", manifest.readingOrder[2].duration.toString())
-    Assert.assertEquals("audio/mpeg", manifest.readingOrder[2].type.toString())
-    Assert.assertEquals("http://www.example.com/2.mp3", manifest.readingOrder[2].hrefURI.toString())
+    Assertions.assertEquals("Track 2", manifest.readingOrder[2].title.toString())
+    Assertions.assertEquals("300.0", manifest.readingOrder[2].duration.toString())
+    Assertions.assertEquals("audio/mpeg", manifest.readingOrder[2].type.toString())
+    Assertions.assertEquals("http://www.example.com/2.mp3", manifest.readingOrder[2].hrefURI.toString())
 
-    Assert.assertEquals("title", manifest.metadata.title)
-    Assert.assertEquals("urn:id", manifest.metadata.identifier)
+    Assertions.assertEquals("title", manifest.metadata.title)
+    Assertions.assertEquals("urn:id", manifest.metadata.identifier)
   }
 
   @Test
@@ -112,7 +112,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -122,13 +122,13 @@ abstract class PlayerManifestContract {
   }
 
   private fun checkNullTitleValues(manifest: PlayerManifest) {
-    Assert.assertEquals(2, manifest.readingOrder.size)
+    Assertions.assertEquals(2, manifest.readingOrder.size)
 
     // null title should be null
-    Assert.assertNull(manifest.readingOrder[0].title)
+    Assertions.assertNull(manifest.readingOrder[0].title)
 
     // no title should be null
-    Assert.assertNull(manifest.readingOrder[1].title)
+    Assertions.assertNull(manifest.readingOrder[1].title)
   }
 
   @Test
@@ -140,7 +140,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -150,13 +150,13 @@ abstract class PlayerManifestContract {
   }
 
   private fun checkNullLinkTypeValues(manifest: PlayerManifest) {
-    Assert.assertEquals(2, manifest.links.size)
+    Assertions.assertEquals(2, manifest.links.size)
 
     // null type should be null
-    Assert.assertNull(manifest.links[0].type)
+    Assertions.assertNull(manifest.links[0].type)
 
     // no type should be null
-    Assert.assertNull(manifest.links[1].type)
+    Assertions.assertNull(manifest.links[1].type)
   }
 
   @Test
@@ -168,7 +168,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -186,7 +186,7 @@ abstract class PlayerManifestContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -196,164 +196,164 @@ abstract class PlayerManifestContract {
   }
 
   private fun checkFlatlandValues(manifest: PlayerManifest) {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Flatland: A Romance of Many Dimensions",
       manifest.metadata.title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "https://librivox.org/flatland-a-romance-of-many-dimensions-by-edwin-abbott-abbott/",
       manifest.metadata.identifier
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       9,
       manifest.readingOrder.size
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 1 - 3",
       manifest.readingOrder[0].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 4 - 5",
       manifest.readingOrder[1].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 6 - 7",
       manifest.readingOrder[2].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 8 - 10",
       manifest.readingOrder[3].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 11 - 12",
       manifest.readingOrder[4].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 13 - 14",
       manifest.readingOrder[5].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 15 - 17",
       manifest.readingOrder[6].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 18 - 20",
       manifest.readingOrder[7].title.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 21 - 22",
       manifest.readingOrder[8].title.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[0].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[1].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[2].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[3].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[4].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[5].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[6].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[7].type.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       manifest.readingOrder[8].type.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1371.0",
       manifest.readingOrder[0].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1669.0",
       manifest.readingOrder[1].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1506.0",
       manifest.readingOrder[2].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1798.0",
       manifest.readingOrder[3].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1225.0",
       manifest.readingOrder[4].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1659.0",
       manifest.readingOrder[5].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "2086.0",
       manifest.readingOrder[6].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "2662.0",
       manifest.readingOrder[7].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1177.0",
       manifest.readingOrder[8].duration.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3",
       manifest.readingOrder[0].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_2_abbott.mp3",
       manifest.readingOrder[1].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_3_abbott.mp3",
       manifest.readingOrder[2].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_4_abbott.mp3",
       manifest.readingOrder[3].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_5_abbott.mp3",
       manifest.readingOrder[4].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_6_abbott.mp3",
       manifest.readingOrder[5].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_7_abbott.mp3",
       manifest.readingOrder[6].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_8_abbott.mp3",
       manifest.readingOrder[7].hrefURI.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_9_abbott.mp3",
       manifest.readingOrder[8].hrefURI.toString()
     )
@@ -368,7 +368,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -386,7 +386,7 @@ abstract class PlayerManifestContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -398,9 +398,9 @@ abstract class PlayerManifestContract {
 
     this.run {
       val sig = extensions[0] as FeedbooksSignature
-      Assert.assertEquals("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", sig.algorithm)
-      Assert.assertEquals("https://www.cantookaudio.com", sig.issuer)
-      Assert.assertEquals(
+      Assertions.assertEquals("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", sig.algorithm)
+      Assertions.assertEquals("https://www.cantookaudio.com", sig.issuer)
+      Assertions.assertEquals(
         "eKLux/4TtJc6VH6RTOi5lBMh9mT1j2y1z50OruWZgy8QjyPMjDV+aVZWUt7OUTinUHQfWNPBB6DxixgTZ07TQsix4uScL2dJZRQTjUKKHv3he7oJdOkcxjWDh51Q6U2KbDfC2MReG/+Qa4meoI5BN0Q8FKIEFMDZJ2KQTSRj13ZETaD0Nwz+8d6IN7csQGFJHvW/bBJthty+eZNzIr+VE0Kf02OS4yX+wvsExfRabvHlfimT1uUTWc89CgPAuM+Y7vdtjb+B3YFr7ibXATk6lQJkXzKol9ms6vkNwnvxzXwsQ+p1ZjejH1LOYADvedl/ItPrBGkhmq7bbUz91jUd+w==",
         sig.value
       )
@@ -408,100 +408,100 @@ abstract class PlayerManifestContract {
 
     this.run {
       val rights = extensions[1] as FeedbooksRights
-      Assert.assertEquals("2020-02-01T17:15:52.000", rights.validStart.toString())
-      Assert.assertEquals("2020-03-29T17:15:52.000", rights.validEnd.toString())
+      Assertions.assertEquals("2020-02-01T17:15:52.000", rights.validStart.toString())
+      Assertions.assertEquals("2020-03-29T17:15:52.000", rights.validEnd.toString())
     }
   }
 
   private fun checkFeedbooks0Values(manifest: PlayerManifest) {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://archive.org/details/gleams_of_sunshine_1607_librivox",
       manifest.metadata.identifier
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Gleams of Sunshine",
       manifest.metadata.title
     )
 
-    Assert.assertEquals(1, manifest.readingOrder.size)
+    Assertions.assertEquals(1, manifest.readingOrder.size)
 
     this.run {
-      Assert.assertEquals(
+      Assertions.assertEquals(
         128.0,
         manifest.readingOrder[0].duration
       )
-      Assert.assertEquals(
+      Assertions.assertEquals(
         "01 - Invocation",
         manifest.readingOrder[0].title
       )
-      Assert.assertEquals(
+      Assertions.assertEquals(
         120.0,
         manifest.readingOrder[0].bitrate
       )
-      Assert.assertEquals(
+      Assertions.assertEquals(
         "audio/mpeg",
         manifest.readingOrder[0].type?.fullType
       )
-      Assert.assertEquals(
+      Assertions.assertEquals(
         "http://archive.org/download/gleams_of_sunshine_1607_librivox/gleamsofsunshine_01_chant.mp3",
         manifest.readingOrder[0].hrefURI.toString()
       )
 
       val encrypted0 = manifest.readingOrder[0].properties.encrypted!!
-      Assert.assertEquals(
+      Assertions.assertEquals(
         "http://www.feedbooks.com/audiobooks/access-restriction",
         encrypted0.scheme
       )
-      Assert.assertEquals(
+      Assertions.assertEquals(
         "https://www.cantookaudio.com",
         (encrypted0.values["profile"] as PlayerManifestScalar.PlayerManifestScalarString).text
       )
     }
 
-    Assert.assertEquals(3, manifest.links.size)
-    Assert.assertEquals(
+    Assertions.assertEquals(3, manifest.links.size)
+    Assertions.assertEquals(
       "cover",
       manifest.links[0].relation[0]
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       180,
       manifest.links[0].width
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       180,
       manifest.links[0].height
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "image/jpeg",
       manifest.links[0].type?.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://archive.org/services/img/gleams_of_sunshine_1607_librivox",
       manifest.links[0].hrefURI.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "self",
       manifest.links[1].relation[0]
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "application/audiobook+json",
       manifest.links[1].type?.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "https://api.archivelab.org/books/gleams_of_sunshine_1607_librivox/opds_audio_manifest",
       manifest.links[1].hrefURI.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "license",
       manifest.links[2].relation[0]
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "application/vnd.readium.license.status.v1.0+json",
       manifest.links[2].type?.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://example.com/license/status",
       manifest.links[2].hrefURI.toString()
     )
@@ -516,54 +516,54 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
 
     val manifest = success.result
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Most Dangerous",
       manifest.metadata.title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "urn:librarysimplified.org/terms/id/Bibliotheca%20ID/hxaee89",
       manifest.metadata.identifier
     )
 
     val encrypted = manifest.metadata.encrypted!!
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://librarysimplified.org/terms/drm/scheme/FAE",
       encrypted.scheme
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED0",
       encrypted.values["findaway:accountId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED1",
       encrypted.values["findaway:checkoutId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED2",
       encrypted.values["findaway:sessionKey"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED3",
       encrypted.values["findaway:fulfillmentId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED4",
       encrypted.values["findaway:licenseId"].toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1",
       manifest.readingOrder[0].properties.extras["findaway:sequence"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       manifest.readingOrder[0].properties.extras["findaway:part"].toString()
     )
@@ -578,54 +578,54 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
 
     val manifest = success.result
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Man Riding West",
       manifest.metadata.title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "urn:librarysimplified.org/terms/id/Bibliotheca%20ID/ebwowg9",
       manifest.metadata.identifier
     )
 
     val encrypted = manifest.metadata.encrypted!!
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://librarysimplified.org/terms/drm/scheme/FAE",
       encrypted.scheme
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED0",
       encrypted.values["findaway:accountId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED1",
       encrypted.values["findaway:checkoutId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED2",
       encrypted.values["findaway:sessionKey"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED3",
       encrypted.values["findaway:fulfillmentId"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "REDACTED4",
       encrypted.values["findaway:licenseId"].toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1",
       manifest.readingOrder[0].properties.extras["findaway:sequence"].toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       manifest.readingOrder[0].properties.extras["findaway:part"].toString()
     )
@@ -640,7 +640,7 @@ abstract class PlayerManifestContract {
         extensions = listOf()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -658,7 +658,7 @@ abstract class PlayerManifestContract {
         extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
       )
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -668,11 +668,11 @@ abstract class PlayerManifestContract {
   }
 
   private fun checkFeedbooks1Values(manifest: PlayerManifest) {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "urn:uuid:35c5e499-9cb9-46e0-9e47-c517973f9e7f",
       manifest.metadata.identifier
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Rise of the Dragons, Book 1",
       manifest.metadata.title
     )
@@ -682,8 +682,8 @@ abstract class PlayerManifestContract {
      * The rest of the test suite should hopefully cover this sufficiently.
      */
 
-    Assert.assertEquals(41, manifest.readingOrder.size)
-    Assert.assertEquals(3, manifest.links.size)
+    Assertions.assertEquals(41, manifest.readingOrder.size)
+    Assertions.assertEquals(3, manifest.links.size)
   }
 
   private fun resource(name: String): ByteArray {

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerPositionParserSerializerContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerPositionParserSerializerContract.kt
@@ -2,8 +2,8 @@ package org.librarysimplified.audiobook.tests
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerPositionParserType
 import org.librarysimplified.audiobook.api.PlayerPositionSerializerType
@@ -30,14 +30,14 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is Success<PlayerPosition, Exception>)
 
     val resultNode = (result as Success<PlayerPosition, Exception>).result
 
-    Assert.assertEquals("A Title", resultNode.title)
-    Assert.assertEquals(23, resultNode.part)
-    Assert.assertEquals(137, resultNode.chapter)
-    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+    Assertions.assertEquals("A Title", resultNode.title)
+    Assertions.assertEquals(23, resultNode.part)
+    Assertions.assertEquals(137, resultNode.chapter)
+    Assertions.assertEquals(183991238L, resultNode.offsetMilliseconds)
   }
 
   @Test
@@ -50,7 +50,7 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
   }
 
   @Test
@@ -64,7 +64,7 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
   }
 
   @Test
@@ -81,7 +81,7 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
   }
 
   @Test
@@ -98,7 +98,7 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
   }
 
   @Test
@@ -115,7 +115,7 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is PlayerResult.Failure<PlayerPosition, Exception>)
   }
 
   @Test
@@ -132,14 +132,14 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is Success<PlayerPosition, Exception>)
 
     val resultNode = (result as Success<PlayerPosition, Exception>).result
 
-    Assert.assertEquals(null, resultNode.title)
-    Assert.assertEquals(23, resultNode.part)
-    Assert.assertEquals(137, resultNode.chapter)
-    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+    Assertions.assertEquals(null, resultNode.title)
+    Assertions.assertEquals(23, resultNode.part)
+    Assertions.assertEquals(137, resultNode.chapter)
+    Assertions.assertEquals(183991238L, resultNode.offsetMilliseconds)
   }
 
   @Test
@@ -154,14 +154,14 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is Success<PlayerPosition, Exception>)
 
     val resultNode = (result as Success<PlayerPosition, Exception>).result
 
-    Assert.assertEquals(null, resultNode.title)
-    Assert.assertEquals(23, resultNode.part)
-    Assert.assertEquals(137, resultNode.chapter)
-    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+    Assertions.assertEquals(null, resultNode.title)
+    Assertions.assertEquals(23, resultNode.part)
+    Assertions.assertEquals(137, resultNode.chapter)
+    Assertions.assertEquals(183991238L, resultNode.offsetMilliseconds)
   }
 
   @Test
@@ -179,13 +179,13 @@ abstract class PlayerPositionParserSerializerContract {
     val result =
       parser.parseFromObjectNode(node)
 
-    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+    Assertions.assertTrue(result is Success<PlayerPosition, Exception>)
 
     val resultNode = (result as Success<PlayerPosition, Exception>).result
 
-    Assert.assertEquals(null, resultNode.title)
-    Assert.assertEquals(23, resultNode.part)
-    Assert.assertEquals(137, resultNode.chapter)
-    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+    Assertions.assertEquals(null, resultNode.title)
+    Assertions.assertEquals(23, resultNode.part)
+    Assertions.assertEquals(137, resultNode.chapter)
+    Assertions.assertEquals(183991238L, resultNode.offsetMilliseconds)
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerResultContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerResultContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerResult.Companion.unit
 
@@ -20,7 +20,7 @@ open class PlayerResultContract {
     val a = 23
     val m = PlayerResult.unit<Int, Unit>(a)
     val f = { y: Int -> PlayerResult.Success<Int, Unit>(y * 2) }
-    Assert.assertEquals(m.flatMap(f), f(a))
+    Assertions.assertEquals(m.flatMap(f), f(a))
   }
 
   /**
@@ -31,7 +31,7 @@ open class PlayerResultContract {
   fun testFlatMapRightIdentity() {
     val m = PlayerResult.unit<Int, Unit>(23)
     val r = m.flatMap { y -> unit<Int, Unit>(y) }
-    Assert.assertEquals(m, r)
+    Assertions.assertEquals(m, r)
   }
 
   /**
@@ -44,7 +44,7 @@ open class PlayerResultContract {
     val f = { y: Int -> unit<Int, Unit>(y * 2) }
     val g = { y: Int -> unit<Int, Unit>(y * 3) }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       m.flatMap(f).flatMap(g),
       m.flatMap({ x -> f(x).flatMap(g) })
     )

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerSleepTimerContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerSleepTimerContract.kt
@@ -1,8 +1,9 @@
 package org.librarysimplified.audiobook.tests
 
 import org.joda.time.Duration
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerCancelled
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerFinished
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerRunning
@@ -28,18 +29,19 @@ abstract class PlayerSleepTimerContract {
   @Test
   fun testOpenClose() {
     val timer = this.create()
-    Assert.assertFalse("Timer not closed", timer.isClosed)
+    Assertions.assertFalse(timer.isClosed, "Timer not closed")
     timer.close()
-    Assert.assertTrue("Timer is closed", timer.isClosed)
+    Assertions.assertTrue(timer.isClosed, "Timer is closed")
     timer.close()
-    Assert.assertTrue("Timer is closed", timer.isClosed)
+    Assertions.assertTrue(timer.isClosed, "Timer is closed")
   }
 
   /**
    * Opening a timer, starting it, and letting it count down to completion works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCountdown() {
     val logger = this.logger()
     val timer = this.create()
@@ -68,7 +70,7 @@ abstract class PlayerSleepTimerContract {
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
-    Assert.assertNotNull(timer.isRunning)
+    Assertions.assertNotNull(timer.isRunning)
     Thread.sleep(1000L)
     Thread.sleep(1000L)
     Thread.sleep(1000L)
@@ -79,21 +81,22 @@ abstract class PlayerSleepTimerContract {
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertEquals(7, events.size)
-    Assert.assertEquals("stopped", events[0])
-    Assert.assertEquals("running", events[1])
-    Assert.assertEquals("running", events[2])
-    Assert.assertEquals("running", events[3])
-    Assert.assertEquals("running", events[4])
-    Assert.assertEquals("finished", events[5])
-    Assert.assertEquals("stopped", events[6])
+    Assertions.assertEquals(7, events.size)
+    Assertions.assertEquals("stopped", events[0])
+    Assertions.assertEquals("running", events[1])
+    Assertions.assertEquals("running", events[2])
+    Assertions.assertEquals("running", events[3])
+    Assertions.assertEquals("running", events[4])
+    Assertions.assertEquals("finished", events[5])
+    Assertions.assertEquals("stopped", events[6])
   }
 
   /**
    * Opening a timer, starting it, and then cancelling it, works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCancel() {
 
     val logger = this.logger()
@@ -123,14 +126,14 @@ abstract class PlayerSleepTimerContract {
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
-    Assert.assertNotNull(timer.isRunning)
+    Assertions.assertNotNull(timer.isRunning)
 
     logger.debug("cancelling timer")
     timer.cancel()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
-    Assert.assertNull(timer.isRunning)
+    Assertions.assertNull(timer.isRunning)
 
     logger.debug("closing timer")
     timer.close()
@@ -138,18 +141,19 @@ abstract class PlayerSleepTimerContract {
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertTrue("Must receive at least 4 events", events.size >= 4)
-    Assert.assertEquals("stopped", events.first())
-    Assert.assertTrue("Received at least a cancelled event", events.contains("cancelled"))
-    Assert.assertTrue("Received at least a running event", events.contains("running"))
-    Assert.assertEquals("stopped", events.last())
+    Assertions.assertTrue(events.size >= 4, "Must receive at least 4 events")
+    Assertions.assertEquals("stopped", events.first())
+    Assertions.assertTrue(events.contains("cancelled"), "Received at least a cancelled event")
+    Assertions.assertTrue(events.contains("running"), "Received at least a running event")
+    Assertions.assertEquals("stopped", events.last())
   }
 
   /**
    * Opening a timer, starting it, and then cancelling it, works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCancelImmediate() {
     val logger = this.logger()
     val timer = this.create()
@@ -179,7 +183,7 @@ abstract class PlayerSleepTimerContract {
     logger.debug("cancelling timer")
     timer.cancel()
     Thread.sleep(250L)
-    Assert.assertNull(timer.isRunning)
+    Assertions.assertNull(timer.isRunning)
 
     logger.debug("closing timer")
     timer.close()
@@ -187,8 +191,8 @@ abstract class PlayerSleepTimerContract {
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertTrue("Must have received at least one events", events.size >= 1)
-    Assert.assertEquals("stopped", events.first())
+    Assertions.assertTrue(events.size >= 1, "Must have received at least one events")
+    Assertions.assertEquals("stopped", events.first())
 
     /*
      * This is timing sensitive. We may not receive a cancelled event if the timer doesn't even
@@ -196,20 +200,21 @@ abstract class PlayerSleepTimerContract {
      */
 
     if (events.size >= 4) {
-      Assert.assertTrue("Received at least a running event", events.contains("running"))
+      Assertions.assertTrue(events.contains("running"), "Received at least a running event")
     }
     if (events.size >= 3) {
-      Assert.assertTrue("Received at least a cancelled event", events.contains("cancelled"))
+      Assertions.assertTrue(events.contains("cancelled"), "Received at least a cancelled event")
     }
 
-    Assert.assertEquals("stopped", events.last())
+    Assertions.assertEquals("stopped", events.last())
   }
 
   /**
    * Opening a timer, starting it, and then restarting it with a new time, works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testRestart() {
     val events = ArrayList<String>()
 
@@ -240,25 +245,26 @@ abstract class PlayerSleepTimerContract {
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
-    Assert.assertNotNull(timer.isRunning)
+    Assertions.assertNotNull(timer.isRunning)
 
     logger.debug("closing timer")
     timer.close()
     Thread.sleep(1000L)
 
     logger.debug("events: {}", events)
-    Assert.assertTrue("Must have received at least 4 events", events.size >= 4)
-    Assert.assertEquals("stopped", events.first())
-    Assert.assertTrue(events.contains("running PT4S"))
-    Assert.assertTrue(events.contains("running PT6S"))
-    Assert.assertEquals("stopped", events.last())
+    Assertions.assertTrue(events.size >= 4, "Must have received at least 4 events")
+    Assertions.assertEquals("stopped", events.first())
+    Assertions.assertTrue(events.contains("running PT4S"))
+    Assertions.assertTrue(events.contains("running PT6S"))
+    Assertions.assertEquals("stopped", events.last())
   }
 
   /**
    * Running the timer to completion repeatedly, works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCompletionRepeated() {
     val logger = this.logger()
     val timer = this.create()
@@ -300,22 +306,23 @@ abstract class PlayerSleepTimerContract {
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertEquals("Must have received 8 events", 8, events.size)
-    Assert.assertEquals("stopped", events[0])
-    Assert.assertEquals("running PT1S", events[1])
-    Assert.assertEquals("running PT0S", events[2])
-    Assert.assertEquals("finished", events[3])
-    Assert.assertEquals("running PT1S", events[4])
-    Assert.assertEquals("running PT0S", events[5])
-    Assert.assertEquals("finished", events[6])
-    Assert.assertEquals("stopped", events[7])
+    Assertions.assertEquals(8, events.size, "Must have received 8 events")
+    Assertions.assertEquals("stopped", events[0])
+    Assertions.assertEquals("running PT1S", events[1])
+    Assertions.assertEquals("running PT0S", events[2])
+    Assertions.assertEquals("finished", events[3])
+    Assertions.assertEquals("running PT1S", events[4])
+    Assertions.assertEquals("running PT0S", events[5])
+    Assertions.assertEquals("finished", events[6])
+    Assertions.assertEquals("stopped", events[7])
   }
 
   /**
    * Explicit completion works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCompletionIndefinite() {
     val logger = this.logger()
     val timer = this.create()
@@ -356,25 +363,26 @@ abstract class PlayerSleepTimerContract {
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
-    Assert.assertNull(timer.isRunning)
+    Assertions.assertNull(timer.isRunning)
 
     timer.close()
 
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertEquals("Must have received 4 events", 4, events.size)
-    Assert.assertEquals("stopped", events[0])
-    Assert.assertEquals("running null", events[1])
-    Assert.assertEquals("finished", events[2])
-    Assert.assertEquals("stopped", events[3])
+    Assertions.assertEquals(4, events.size, "Must have received 4 events")
+    Assertions.assertEquals("stopped", events[0])
+    Assertions.assertEquals("running null", events[1])
+    Assertions.assertEquals("finished", events[2])
+    Assertions.assertEquals("stopped", events[3])
   }
 
   /**
    * Explicit completion works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testCompletionTimed() {
     val logger = this.logger()
     val timer = this.create()
@@ -415,18 +423,19 @@ abstract class PlayerSleepTimerContract {
     waitLatch.await()
 
     logger.debug("events: {}", events)
-    Assert.assertEquals("Must have received 4 events", 4, events.size)
-    Assert.assertEquals("stopped", events[0])
-    Assert.assertEquals("running PT2S", events[1])
-    Assert.assertEquals("finished", events[2])
-    Assert.assertEquals("stopped", events[3])
+    Assertions.assertEquals(4, events.size, "Must have received 4 events")
+    Assertions.assertEquals("stopped", events[0])
+    Assertions.assertEquals("running PT2S", events[1])
+    Assertions.assertEquals("finished", events[2])
+    Assertions.assertEquals("stopped", events[3])
   }
 
   /**
    * Pausing a timer works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testPause() {
     val logger = this.logger()
     val timer = this.create()
@@ -459,7 +468,7 @@ abstract class PlayerSleepTimerContract {
     timer.pause()
     Thread.sleep(1000L)
     val running = timer.isRunning!!
-    Assert.assertTrue("Is paused", running.paused)
+    Assertions.assertTrue(running.paused, "Is paused")
 
     Thread.sleep(1000L)
     Thread.sleep(1000L)
@@ -474,18 +483,19 @@ abstract class PlayerSleepTimerContract {
     logger.debug("distinctEvents: {}", distinctEvents)
 
     logger.debug("events: {}", events)
-    Assert.assertEquals(4, distinctEvents.size)
-    Assert.assertEquals("stopped", distinctEvents[0])
-    Assert.assertEquals("running", distinctEvents[1])
-    Assert.assertEquals("running paused", distinctEvents[2])
-    Assert.assertEquals("stopped", distinctEvents[3])
+    Assertions.assertEquals(4, distinctEvents.size)
+    Assertions.assertEquals("stopped", distinctEvents[0])
+    Assertions.assertEquals("running", distinctEvents[1])
+    Assertions.assertEquals("running paused", distinctEvents[2])
+    Assertions.assertEquals("stopped", distinctEvents[3])
   }
 
   /**
    * Pausing and unpausing a timer works.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testUnpause() {
     val logger = this.logger()
     val timer = this.create()
@@ -517,14 +527,14 @@ abstract class PlayerSleepTimerContract {
 
     Thread.sleep(1000L)
     val running = timer.isRunning!!
-    Assert.assertTrue("Is paused", running.paused)
+    Assertions.assertTrue(running.paused, "Is paused")
 
     Thread.sleep(1000L)
 
     timer.unpause()
     Thread.sleep(1000L)
     val stillRunning = timer.isRunning!!
-    Assert.assertFalse("Is not paused", stillRunning.paused)
+    Assertions.assertFalse(stillRunning.paused, "Is not paused")
 
     Thread.sleep(1000L)
     Thread.sleep(1000L)
@@ -540,20 +550,21 @@ abstract class PlayerSleepTimerContract {
     val distinctEvents = withoutSuccessiveDuplicates(events)
     logger.debug("distinctEvents: {}", distinctEvents)
 
-    Assert.assertEquals(6, distinctEvents.size)
-    Assert.assertEquals("stopped", distinctEvents[0])
-    Assert.assertEquals("running", distinctEvents[1])
-    Assert.assertEquals("running paused", distinctEvents[2])
-    Assert.assertEquals("running", distinctEvents[3])
-    Assert.assertEquals("finished", distinctEvents[4])
-    Assert.assertEquals("stopped", distinctEvents[5])
+    Assertions.assertEquals(6, distinctEvents.size)
+    Assertions.assertEquals("stopped", distinctEvents[0])
+    Assertions.assertEquals("running", distinctEvents[1])
+    Assertions.assertEquals("running paused", distinctEvents[2])
+    Assertions.assertEquals("running", distinctEvents[3])
+    Assertions.assertEquals("finished", distinctEvents[4])
+    Assertions.assertEquals("stopped", distinctEvents[5])
   }
 
   /**
    * Sending unpause requests to an unpaused timer is redundant.
    */
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   fun testUnpauseRedundant() {
     val logger = this.logger()
     val timer = this.create()
@@ -585,12 +596,12 @@ abstract class PlayerSleepTimerContract {
 
     Thread.sleep(1000L)
     val running = timer.isRunning!!
-    Assert.assertFalse("Is paused", running.paused)
+    Assertions.assertFalse(running.paused, "Is paused")
 
     timer.unpause()
     Thread.sleep(1000L)
     val stillRunning = timer.isRunning!!
-    Assert.assertFalse("Is not paused", stillRunning.paused)
+    Assertions.assertFalse(stillRunning.paused, "Is not paused")
 
     Thread.sleep(1000L)
     Thread.sleep(1000L)
@@ -605,11 +616,11 @@ abstract class PlayerSleepTimerContract {
     val distinctEvents = withoutSuccessiveDuplicates(events)
     logger.debug("distinctEvents: {}", distinctEvents)
 
-    Assert.assertEquals(4, distinctEvents.size)
-    Assert.assertEquals("stopped", distinctEvents[0])
-    Assert.assertEquals("running", distinctEvents[1])
-    Assert.assertEquals("finished", distinctEvents[2])
-    Assert.assertEquals("stopped", distinctEvents[3])
+    Assertions.assertEquals(4, distinctEvents.size)
+    Assertions.assertEquals("stopped", distinctEvents[0])
+    Assertions.assertEquals("running", distinctEvents[1])
+    Assertions.assertEquals("finished", distinctEvents[2])
+    Assertions.assertEquals("stopped", distinctEvents[3])
   }
 
   private fun <T> withoutSuccessiveDuplicates(values: List<T>): List<T> {

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerTimeStringsContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerTimeStringsContract.kt
@@ -1,8 +1,8 @@
 package org.librarysimplified.audiobook.tests
 
 import org.joda.time.Duration
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.views.PlayerTimeStrings
 
 abstract class PlayerTimeStringsContract {
@@ -23,7 +23,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromMillis_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:00:00",
       PlayerTimeStrings.hourMinuteSecondTextFromMilliseconds(0)
     )
@@ -31,7 +31,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromMillis_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:00:01",
       PlayerTimeStrings.hourMinuteSecondTextFromMilliseconds(Duration.standardSeconds(1).millis)
     )
@@ -39,7 +39,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromMillis_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:01:00",
       PlayerTimeStrings.hourMinuteSecondTextFromMilliseconds(Duration.standardMinutes(1).millis)
     )
@@ -47,7 +47,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromMillis_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "01:00:00",
       PlayerTimeStrings.hourMinuteSecondTextFromMilliseconds(Duration.standardHours(1).millis)
     )
@@ -55,7 +55,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromMillis_4() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59:59:59",
       PlayerTimeStrings.hourMinuteSecondTextFromMilliseconds(
         Duration.standardHours(59)
@@ -68,7 +68,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:00:00",
       PlayerTimeStrings.hourMinuteSecondTextFromDuration(Duration.ZERO)
     )
@@ -76,7 +76,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:00:01",
       PlayerTimeStrings.hourMinuteSecondTextFromDuration(Duration.standardSeconds(1))
     )
@@ -84,7 +84,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:01:00",
       PlayerTimeStrings.hourMinuteSecondTextFromDuration(Duration.standardMinutes(1))
     )
@@ -92,7 +92,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsTextFromDuration_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "01:00:00",
       PlayerTimeStrings.hourMinuteSecondTextFromDuration(Duration.standardHours(1))
     )
@@ -105,7 +105,7 @@ abstract class PlayerTimeStringsContract {
         .plus(Duration.standardMinutes(59))
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59:59:59",
       PlayerTimeStrings.hourMinuteSecondTextFromDuration(time)
     )
@@ -113,7 +113,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsTextFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:00",
       PlayerTimeStrings.minuteSecondTextFromDuration(Duration.ZERO)
     )
@@ -121,7 +121,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsTextFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "00:01",
       PlayerTimeStrings.minuteSecondTextFromDuration(Duration.standardSeconds(1))
     )
@@ -129,7 +129,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsTextFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "01:00",
       PlayerTimeStrings.minuteSecondTextFromDuration(Duration.standardMinutes(1))
     )
@@ -141,7 +141,7 @@ abstract class PlayerTimeStringsContract {
       Duration.standardMinutes(59)
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59:59",
       PlayerTimeStrings.minuteSecondTextFromDuration(time)
     )
@@ -149,7 +149,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromMillis_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(this.spokenEnglish, 0)
     )
@@ -157,7 +157,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromMillis_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 second",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenEnglish,
@@ -168,7 +168,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromMillis_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minute",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenEnglish,
@@ -179,7 +179,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromMillis_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 hour",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenEnglish,
@@ -190,7 +190,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromMillis_4() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 hours 59 minutes 59 seconds",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenEnglish,
@@ -204,7 +204,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(this.spokenEnglish, Duration.ZERO)
     )
@@ -212,7 +212,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 second",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenEnglish,
@@ -223,7 +223,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minute",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenEnglish,
@@ -234,7 +234,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenEnglishFromDuration_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 hour",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenEnglish,
@@ -250,7 +250,7 @@ abstract class PlayerTimeStringsContract {
         .plus(Duration.standardMinutes(59))
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 hours 59 minutes 59 seconds",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(this.spokenEnglish, time)
     )
@@ -258,7 +258,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenEnglishFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenEnglish, Duration.ZERO)
     )
@@ -266,7 +266,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenEnglishFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 second",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(
         this.spokenEnglish,
@@ -277,7 +277,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenEnglishFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minute",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(
         this.spokenEnglish,
@@ -292,7 +292,7 @@ abstract class PlayerTimeStringsContract {
       Duration.standardMinutes(59)
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 minutes 59 seconds",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenEnglish, time)
     )
@@ -302,7 +302,7 @@ abstract class PlayerTimeStringsContract {
   fun testMinuteSecondsSpokenEnglishFromDuration_5() {
     val time = Duration.standardMinutes(60)
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "60 minutes",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenEnglish, time)
     )
@@ -310,7 +310,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromMillis_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(this.spokenSpanish, 0)
     )
@@ -318,7 +318,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromMillis_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 segundo",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenSpanish,
@@ -329,7 +329,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromMillis_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minuto",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenSpanish,
@@ -340,7 +340,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromMillis_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 hora",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenSpanish,
@@ -351,7 +351,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromMillis_4() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 horas 59 minutos 59 segundos",
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(
         this.spokenSpanish,
@@ -365,7 +365,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(this.spokenSpanish, Duration.ZERO)
     )
@@ -373,7 +373,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 segundo",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenSpanish,
@@ -384,7 +384,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minuto",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenSpanish,
@@ -395,7 +395,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testHourMinuteSecondsSpokenSpanishFromDuration_3() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 hora",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(
         this.spokenSpanish,
@@ -411,7 +411,7 @@ abstract class PlayerTimeStringsContract {
         .plus(Duration.standardMinutes(59))
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 horas 59 minutos 59 segundos",
       PlayerTimeStrings.hourMinuteSecondSpokenFromDuration(this.spokenSpanish, time)
     )
@@ -419,7 +419,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenSpanishFromDuration_0() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenSpanish, Duration.ZERO)
     )
@@ -427,7 +427,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenSpanishFromDuration_1() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 segundo",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(
         this.spokenSpanish,
@@ -438,7 +438,7 @@ abstract class PlayerTimeStringsContract {
 
   @Test
   fun testMinuteSecondsSpokenSpanishFromDuration_2() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1 minuto",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(
         this.spokenSpanish,
@@ -453,7 +453,7 @@ abstract class PlayerTimeStringsContract {
       Duration.standardMinutes(59)
         .plus(Duration.standardSeconds(59))
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "59 minutos 59 segundos",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenSpanish, time)
     )
@@ -463,7 +463,7 @@ abstract class PlayerTimeStringsContract {
   fun testMinuteSecondsSpokenSpanishFromDuration_5() {
     val time = Duration.standardMinutes(60)
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "60 minutos",
       PlayerTimeStrings.minuteSecondSpokenFromDuration(this.spokenSpanish, time)
     )

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoManifestContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoManifestContract.kt
@@ -1,8 +1,8 @@
 package org.librarysimplified.audiobook.tests.open_access
 
-import org.junit.Assert
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
 import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
@@ -29,7 +29,7 @@ abstract class ExoManifestContract {
       )
 
     this.log().debug("result: {}", result)
-    assertTrue("Result is success", result is ParseResult.Success)
+    assertTrue(result is ParseResult.Success, "Result is success")
 
     val success: ParseResult.Success<PlayerManifest> =
       result as ParseResult.Success<PlayerManifest>
@@ -38,245 +38,245 @@ abstract class ExoManifestContract {
 
     val exo_result = ExoManifest.transform(manifest)
     this.log().debug("exo_result: {}", exo_result)
-    assertTrue("Result is success", exo_result is PlayerResult.Success)
+    assertTrue(exo_result is PlayerResult.Success, "Result is success")
 
     val exo_success: PlayerResult.Success<ExoManifest, Exception> =
       exo_result as PlayerResult.Success<ExoManifest, Exception>
 
     val exo = exo_success.result
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Flatland: A Romance of Many Dimensions",
       exo.title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "https://librivox.org/flatland-a-romance-of-many-dimensions-by-edwin-abbott-abbott/",
       exo.id
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       9,
       exo.spineItems.size
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 1 - 3",
       exo.spineItems[0].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 4 - 5",
       exo.spineItems[1].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 6 - 7",
       exo.spineItems[2].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 8 - 10",
       exo.spineItems[3].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 1, Sections 11 - 12",
       exo.spineItems[4].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 13 - 14",
       exo.spineItems[5].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 15 - 17",
       exo.spineItems[6].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 18 - 20",
       exo.spineItems[7].title
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "Part 2, Sections 21 - 22",
       exo.spineItems[8].title
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[0].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[1].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[2].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[3].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[4].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[5].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[6].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[7].type.fullType
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "audio/mpeg",
       exo.spineItems[8].type.fullType
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1371.0",
       exo.spineItems[0].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1669.0",
       exo.spineItems[1].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1506.0",
       exo.spineItems[2].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1798.0",
       exo.spineItems[3].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1225.0",
       exo.spineItems[4].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1659.0",
       exo.spineItems[5].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "2086.0",
       exo.spineItems[6].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "2662.0",
       exo.spineItems[7].duration.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1177.0",
       exo.spineItems[8].duration.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3",
       exo.spineItems[0].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_2_abbott.mp3",
       exo.spineItems[1].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_3_abbott.mp3",
       exo.spineItems[2].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_4_abbott.mp3",
       exo.spineItems[3].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_5_abbott.mp3",
       exo.spineItems[4].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_6_abbott.mp3",
       exo.spineItems[5].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_7_abbott.mp3",
       exo.spineItems[6].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_8_abbott.mp3",
       exo.spineItems[7].uri.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "http://www.archive.org/download/flatland_rg_librivox/flatland_9_abbott.mp3",
       exo.spineItems[8].uri.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[0].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[1].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[2].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[3].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[4].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[5].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[6].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[7].part.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[8].part.toString()
     )
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "0",
       exo.spineItems[0].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "1",
       exo.spineItems[1].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "2",
       exo.spineItems[2].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "3",
       exo.spineItems[3].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "4",
       exo.spineItems[4].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "5",
       exo.spineItems[5].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "6",
       exo.spineItems[6].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "7",
       exo.spineItems[7].chapter.toString()
     )
-    Assert.assertEquals(
+    Assertions.assertEquals(
       "8",
       exo.spineItems[8].chapter.toString()
     )

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/rbdigital/RBDigitalLinkDocumentParserContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/rbdigital/RBDigitalLinkDocumentParserContract.kt
@@ -1,8 +1,8 @@
 package org.librarysimplified.audiobook.tests.rbdigital
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.rbdigital.RBDigitalLinkDocumentParser
 import org.librarysimplified.audiobook.rbdigital.RBDigitalLinkDocumentParser.ParseResult.ParseFailed
 import org.librarysimplified.audiobook.rbdigital.RBDigitalLinkDocumentParser.ParseResult.ParseSuccess
@@ -24,10 +24,10 @@ abstract class RBDigitalLinkDocumentParserContract {
     objectNode.put("url", "http://www.example.com")
 
     val result = parser.parseFromObjectNode(objectNode)
-    Assert.assertTrue(result is ParseSuccess)
+    Assertions.assertTrue(result is ParseSuccess)
     val document = result as ParseSuccess
-    Assert.assertEquals("application/octet-stream", document.document.type)
-    Assert.assertEquals("http://www.example.com", document.document.uri.toString())
+    Assertions.assertEquals("application/octet-stream", document.document.type)
+    Assertions.assertEquals("http://www.example.com", document.document.uri.toString())
   }
 
   @Test
@@ -38,7 +38,7 @@ abstract class RBDigitalLinkDocumentParserContract {
     objectNode.put("url", "http://www.example.com")
 
     val result = parser.parseFromObjectNode(objectNode)
-    Assert.assertTrue(result is ParseFailed)
+    Assertions.assertTrue(result is ParseFailed)
   }
 
   @Test
@@ -49,7 +49,7 @@ abstract class RBDigitalLinkDocumentParserContract {
     objectNode.put("type", "application/octet-stream")
 
     val result = parser.parseFromObjectNode(objectNode)
-    Assert.assertTrue(result is ParseFailed)
+    Assertions.assertTrue(result is ParseFailed)
   }
 
   @Test
@@ -59,7 +59,7 @@ abstract class RBDigitalLinkDocumentParserContract {
     val node = this.mapper.createArrayNode()
 
     val result = parser.parseFromNode(node)
-    Assert.assertTrue(result is ParseFailed)
+    Assertions.assertTrue(result is ParseFailed)
   }
 
   @Test
@@ -72,10 +72,10 @@ abstract class RBDigitalLinkDocumentParserContract {
 
     ByteArrayInputStream(this.mapper.writeValueAsBytes(objectNode)).use { stream ->
       val result = parser.parseFromStream(stream)
-      Assert.assertTrue(result is ParseSuccess)
+      Assertions.assertTrue(result is ParseSuccess)
       val document = result as ParseSuccess
-      Assert.assertEquals("application/octet-stream", document.document.type)
-      Assert.assertEquals("http://www.example.com", document.document.uri.toString())
+      Assertions.assertEquals("application/octet-stream", document.document.type)
+      Assertions.assertEquals("http://www.example.com", document.document.uri.toString())
     }
   }
 
@@ -92,10 +92,10 @@ abstract class RBDigitalLinkDocumentParserContract {
 
     FileInputStream(file).use { stream ->
       val result = parser.parseFromStream(stream)
-      Assert.assertTrue(result is ParseSuccess)
+      Assertions.assertTrue(result is ParseSuccess)
       val document = result as ParseSuccess
-      Assert.assertEquals("application/octet-stream", document.document.type)
-      Assert.assertEquals("http://www.example.com", document.document.uri.toString())
+      Assertions.assertEquals("application/octet-stream", document.document.type)
+      Assertions.assertEquals("http://www.example.com", document.document.uri.toString())
     }
   }
 }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/rbdigital/RBDigitalPlayerExtensionContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/rbdigital/RBDigitalPlayerExtensionContract.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.tests.rbdigital
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
 import org.librarysimplified.audiobook.rbdigital.RBDigitialPlayerExtension
 
@@ -12,6 +12,6 @@ abstract class RBDigitalPlayerExtensionContract {
   @Test
   fun hasCorrectServiceType() {
     val extensions = ServiceLoader.load(PlayerExtensionType::class.java).toList()
-    Assert.assertTrue(extensions.any({ extension -> extension is RBDigitialPlayerExtension }))
+    Assertions.assertTrue(extensions.any({ extension -> extension is RBDigitialPlayerExtension }))
   }
 }


### PR DESCRIPTION
This gets unit tests running again. They haven't been running for some time, probably because we started using JUnit 5 in android-platform, but the tests were still written for JUnit 4. This fully upgrades everything to JUnit 5.

This does not fix the UI (Espresso-based) tests in org.librarysimplified.audiobook.tests.device, which don't appear to have worked in a long time. The Appium-based test suite that A1QA maintains will replace those anyway, so we probably don't need them.