### PR TITLE
Fixed controls not being correctly displayed in Android 12 lock screen

### DIFF
--- a/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
+++ b/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<manifest package="org.librarysimplified.audiobook.views"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.librarysimplified.audiobook.views">
+
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <application>
         <service
             android:name="org.librarysimplified.audiobook.views.PlayerService"
             android:enabled="true"
             android:exported="false" />
+
+        <receiver
+            android:name="androidx.media.session.MediaButtonReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -566,7 +566,7 @@ class PlayerFragment : Fragment() {
 
         val element = event.spineElement
         if (element != null) {
-          this.configureSpineElementText(element)
+          this.configureSpineElementText(element, isPlaying = false)
           this.onEventUpdateTimeRelatedUI(element, event.offsetMilliseconds)
         }
       }
@@ -582,7 +582,7 @@ class PlayerFragment : Fragment() {
         this.playerWaiting.contentDescription = null
         this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityIsWaitingForChapter(text))
 
-        this.configureSpineElementText(event.spineElement)
+        this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, 0)
       }
     )
@@ -592,7 +592,7 @@ class PlayerFragment : Fragment() {
     UIThread.runOnUIThread(
       Runnable {
         this.onPlayerBufferingStarted()
-        this.configureSpineElementText(event.spineElement)
+        this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
       }
     )
@@ -631,7 +631,7 @@ class PlayerFragment : Fragment() {
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
-        this.configureSpineElementText(event.spineElement)
+        this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
       }
     )
@@ -645,7 +645,7 @@ class PlayerFragment : Fragment() {
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
-        this.configureSpineElementText(event.spineElement)
+        this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
       }
     )
@@ -692,7 +692,7 @@ class PlayerFragment : Fragment() {
         this.playPauseButton.setImageResource(R.drawable.pause_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPause() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_pause)
-        this.configureSpineElementText(event.spineElement)
+        this.configureSpineElementText(event.spineElement, isPlaying = true)
         this.playerPosition.isEnabled = true
         this.playerWaiting.text = ""
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
@@ -732,6 +732,16 @@ class PlayerFragment : Fragment() {
       this.playerTimeCurrentSpoken(offsetMilliseconds)
 
     this.playerSpineElement.text = this.spineElementText(spineElement)
+
+    // we just update the book chapter on the playerInfoModel if it's been initialized
+    if (::playerInfoModel.isInitialized) {
+
+      this.playerInfoModel = this.playerInfoModel.copy(
+        bookChapterName = this.spineElementText(spineElement)
+      )
+
+      playerService.updatePlayerInfo(playerInfoModel)
+    }
   }
 
   private fun playerTimeCurrentSpoken(offsetMilliseconds: Long): String {
@@ -784,8 +794,19 @@ class PlayerFragment : Fragment() {
    * description to give the same information.
    */
 
-  private fun configureSpineElementText(element: PlayerSpineElementType) {
+  private fun configureSpineElementText(element: PlayerSpineElementType, isPlaying: Boolean) {
     this.playerSpineElement.text = this.spineElementText(element)
+
+    // we just update the book chapter on the playerInfoModel if it's been initialized
+    if (::playerInfoModel.isInitialized) {
+
+      this.playerInfoModel = this.playerInfoModel.copy(
+        bookChapterName = this.spineElementText(element),
+        isPlaying = isPlaying
+      )
+
+      playerService.updatePlayerInfo(playerInfoModel)
+    }
 
     val accessibilityTitle = element.title ?: this.getString(
       R.string.audiobook_accessibility_toc_chapter_n,

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -8,13 +8,16 @@ import android.content.IntentFilter
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
 import androidx.core.app.NotificationCompat
+
 
 class PlayerService : Service() {
 
   companion object {
-    private const val NOTIFICATION_CHANNEL_ID = "AudiobookPlayerCommands"
-    private const val NOTIFICATION_CHANNEL_NAME = "Audiobook player commands"
+    private const val NOTIFICATION_CHANNEL_ID = "Audiobook_Player_Commands"
+    private const val NOTIFICATION_CHANNEL_NAME = "Audiobook Player Commands"
 
     private const val ACTION_PLAY = "org.librarysimplified.audiobook.views.action_play"
     private const val ACTION_PAUSE = "org.librarysimplified.audiobook.views.action_pause"
@@ -23,7 +26,23 @@ class PlayerService : Service() {
   private lateinit var playerReceiver: PlayerBroadcastReceiver
   private lateinit var playerInfo: PlayerInfoModel
 
+  private var mediaSession: MediaSessionCompat? = null
+
   private val binder = PlayerBinder()
+
+  private val playIntent by lazy {
+    PendingIntent.getBroadcast(
+      this, 0, Intent(ACTION_PLAY),
+      PendingIntent.FLAG_UPDATE_CURRENT
+    )
+  }
+
+  private val pauseIntent by lazy {
+    PendingIntent.getBroadcast(
+      this, 0, Intent(ACTION_PAUSE),
+      PendingIntent.FLAG_UPDATE_CURRENT
+    )
+  }
 
   override fun onBind(intent: Intent?): IBinder {
     return binder
@@ -47,6 +66,7 @@ class PlayerService : Service() {
     if (!this.playerInfo.player.isClosed) {
       this.playerInfo.player.close()
     }
+    mediaSession?.release()
     unregisterReceiver(playerReceiver)
     super.onDestroy()
   }
@@ -59,11 +79,12 @@ class PlayerService : Service() {
       val notificationChannel = NotificationChannel(
         NOTIFICATION_CHANNEL_ID,
         NOTIFICATION_CHANNEL_NAME,
-        NotificationManager.IMPORTANCE_DEFAULT
+        NotificationManager.IMPORTANCE_LOW
       )
         .apply {
           this.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
           this.setShowBadge(false)
+          this.enableVibration(false)
         }
 
       notificationManager.createNotificationChannel(notificationChannel)
@@ -72,13 +93,16 @@ class PlayerService : Service() {
 
   private fun updateNotification() {
 
-    val playIntent = PendingIntent.getBroadcast(
-      this, 0, Intent(ACTION_PLAY),
-      PendingIntent.FLAG_UPDATE_CURRENT
-    )
-    val pauseIntent = PendingIntent.getBroadcast(
-      this, 0, Intent(ACTION_PAUSE),
-      PendingIntent.FLAG_UPDATE_CURRENT
+    if (mediaSession == null) {
+      mediaSession = MediaSessionCompat(this, PlayerService::class.java.simpleName)
+    }
+
+    mediaSession?.setMetadata(
+      MediaMetadataCompat.Builder()
+        .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, playerInfo.bookCover)
+        .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, playerInfo.bookChapterName)
+        .putString(MediaMetadataCompat.METADATA_KEY_TITLE, playerInfo.bookName)
+        .build()
     )
 
     val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
@@ -88,10 +112,12 @@ class PlayerService : Service() {
         androidx.media.app.NotificationCompat.MediaStyle()
           .setShowActionsInCompactView(0)
           .setShowCancelButton(false)
+          .setMediaSession(mediaSession?.sessionToken)
       )
       .setSmallIcon(this.playerInfo.smallIcon)
       .setLargeIcon(this.playerInfo.bookCover)
       .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+      .setNotificationSilent()
       .addAction(
         if (this.playerInfo.isPlaying) {
           NotificationCompat.Action(R.drawable.ic_pause, "Pause", pauseIntent)
@@ -114,12 +140,14 @@ class PlayerService : Service() {
     override fun onReceive(context: Context?, intent: Intent?) {
       val action = intent?.action
       if (action == ACTION_PLAY) {
+        mediaSession?.isActive = true
         playerInfo.player.play()
         playerInfo = playerInfo.copy(
           isPlaying = true
         )
         updateNotification()
       } else if (action == ACTION_PAUSE) {
+        mediaSession?.isActive = false
         playerInfo.player.pause()
         playerInfo = playerInfo.copy(
           isPlaying = false

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -13,8 +13,8 @@ import androidx.core.app.NotificationCompat
 class PlayerService : Service() {
 
   companion object {
-    private const val NOTIFICATION_CHANNEL_ID = "AudiobookCommands"
-    private const val NOTIFICATION_CHANNEL_NAME = "Audiobook commands"
+    private const val NOTIFICATION_CHANNEL_ID = "AudiobookPlayerCommands"
+    private const val NOTIFICATION_CHANNEL_NAME = "Audiobook player commands"
 
     private const val ACTION_PLAY = "org.librarysimplified.audiobook.views.action_play"
     private const val ACTION_PAUSE = "org.librarysimplified.audiobook.views.action_pause"
@@ -54,13 +54,17 @@ class PlayerService : Service() {
   private fun createNotificationChannel() {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-      val notificationChannel = NotificationChannel(NOTIFICATION_CHANNEL_ID,
+      val notificationManager =
+        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      val notificationChannel = NotificationChannel(
+        NOTIFICATION_CHANNEL_ID,
         NOTIFICATION_CHANNEL_NAME,
-        NotificationManager.IMPORTANCE_LOW).apply {
-        this.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-        this.setShowBadge(false)
-      }
+        NotificationManager.IMPORTANCE_DEFAULT
+      )
+        .apply {
+          this.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+          this.setShowBadge(false)
+        }
 
       notificationManager.createNotificationChannel(notificationChannel)
     }
@@ -68,17 +72,23 @@ class PlayerService : Service() {
 
   private fun updateNotification() {
 
-    val playIntent = PendingIntent.getBroadcast(this, 0, Intent(ACTION_PLAY),
-      PendingIntent.FLAG_UPDATE_CURRENT)
-    val pauseIntent = PendingIntent.getBroadcast(this, 0, Intent(ACTION_PAUSE),
-      PendingIntent.FLAG_UPDATE_CURRENT)
+    val playIntent = PendingIntent.getBroadcast(
+      this, 0, Intent(ACTION_PLAY),
+      PendingIntent.FLAG_UPDATE_CURRENT
+    )
+    val pauseIntent = PendingIntent.getBroadcast(
+      this, 0, Intent(ACTION_PAUSE),
+      PendingIntent.FLAG_UPDATE_CURRENT
+    )
 
     val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
       .setContentTitle(this.playerInfo.bookName)
       .setContentText(this.playerInfo.bookChapterName)
-      .setStyle(androidx.media.app.NotificationCompat.MediaStyle()
-        .setShowActionsInCompactView(0)
-        .setShowCancelButton(false))
+      .setStyle(
+        androidx.media.app.NotificationCompat.MediaStyle()
+          .setShowActionsInCompactView(0)
+          .setShowCancelButton(false)
+      )
       .setSmallIcon(this.playerInfo.smallIcon)
       .setLargeIcon(this.playerInfo.bookCover)
       .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -86,8 +96,9 @@ class PlayerService : Service() {
         if (this.playerInfo.isPlaying) {
           NotificationCompat.Action(R.drawable.ic_pause, "Pause", pauseIntent)
         } else {
-          NotificationCompat.Action(R.drawable.ic_play, "Play1", playIntent)
-        })
+          NotificationCompat.Action(R.drawable.ic_play, "Play", playIntent)
+        }
+      )
       .build()
 
     startForeground(1, notification)


### PR DESCRIPTION
**What's this do?**
This PR changes the importance of the created notification channel for the audiobook controls so they can have a proper behavior when the screen is locked.

**Why are we doing this? (w/ JIRA link if applicable)**
In some devices the notification wasn't being correctly displayed in the lock screen. Sometimes it would appear fully collapsed which required the user to unlock the screen to be able to perform the play/pause actions.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Open any audiobook
Drag down the status bar and verify that a notification has been created
with the book info
Turn off the screen
Turn on the screen and [check the notification is visible](https://user-images.githubusercontent.com/79104027/146753857-709d8d64-7967-43f5-9361-7758cc792c37.png)
Press pause/play and verify the player pauses and resumes

**Did someone actually run this code to verify it works?**
Tested by @nunommts