### PR TITLE
Parse manifest text starting with "0" into a string.

### DIFF
--- a/org.librarysimplified.audiobook.manifest_parser.webpub/src/main/java/org/librarysimplified/audiobook/manifest_parser/webpub/WebPubScalarParsers.kt
+++ b/org.librarysimplified.audiobook.manifest_parser.webpub/src/main/java/org/librarysimplified/audiobook/manifest_parser/webpub/WebPubScalarParsers.kt
@@ -20,23 +20,29 @@ object WebPubScalarParsers {
     text: String
   ): FRParseResult<PlayerManifestScalar> {
     return FRParseResult.succeed(
-      when (val integer = text.toIntOrNull()) {
-        null ->
-          when (val double = text.toDoubleOrNull()) {
-            null ->
-              when (text) {
-                "true" ->
-                  PlayerManifestScalarBoolean(true)
-                "false" ->
-                  PlayerManifestScalarBoolean(false)
-                else ->
-                  PlayerManifestScalarString(text)
-              }
-            else ->
-              PlayerManifestScalarReal(double)
-          }
-        else ->
-          PlayerManifestScalarInteger(integer)
+      if (text.startsWith("0")) {
+        // If the text begins with "0", parse it into a string to ensure that the leading "0" is retained.
+        PlayerManifestScalarString(text)
+      }
+      else {
+        when (val integer = text.toIntOrNull()) {
+          null ->
+            when (val double = text.toDoubleOrNull()) {
+              null ->
+                when (text) {
+                  "true" ->
+                    PlayerManifestScalarBoolean(true)
+                  "false" ->
+                    PlayerManifestScalarBoolean(false)
+                  else ->
+                    PlayerManifestScalarString(text)
+                }
+              else ->
+                PlayerManifestScalarReal(double)
+            }
+          else ->
+            PlayerManifestScalarInteger(integer)
+        }
       }
     )
   }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
@@ -632,6 +632,30 @@ abstract class PlayerManifestContract {
   }
 
   @Test
+  fun testOkFindawayLeading0() {
+    val result =
+      ManifestParsers.parse(
+        uri = URI.create("findaway"),
+        streams = this.resource("findaway_leading_0.json"),
+        extensions = listOf()
+      )
+    this.log().debug("result: {}", result)
+    assertTrue(result is ParseResult.Success, "Result is success")
+
+    val success: ParseResult.Success<PlayerManifest> =
+      result as ParseResult.Success<PlayerManifest>
+
+    val manifest = success.result
+
+    val encrypted = manifest.metadata.encrypted!!
+
+    Assertions.assertEquals(
+      "012345",
+      encrypted.values["findaway:fulfillmentId"].toString()
+    )
+  }
+
+  @Test
   fun testOkFeedbooks1() {
     val result =
       ManifestParsers.parse(

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/findaway_leading_0.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/findaway_leading_0.json
@@ -1,0 +1,37 @@
+{
+  "readingOrder": [
+    {
+      "title": "Track 1",
+      "findaway:sequence": 1,
+      "href": null,
+      "duration": 10.000,
+      "findaway:part": 0,
+      "type": "audio/mpeg"
+    }
+  ],
+  "@context": [
+    "http://readium.org/webpub/default.jsonld",
+    {
+      "findaway": "http://librarysimplified.org/terms/third-parties/findaway.com/"
+    }
+  ],
+  "metadata": {
+    "language": "en",
+    "title": "Juggler of Worlds",
+    "encrypted": {
+      "findaway:accountId": "REDACTED0",
+      "findaway:checkoutId": "REDACTED1",
+      "findaway:sessionKey": "REDACTED2",
+      "findaway:fulfillmentId": "012345",
+      "findaway:licenseId": "REDACTED4",
+      "scheme": "http://librarysimplified.org/terms/drm/scheme/FAE"
+    },
+    "authors": [
+      "Larry Niven",
+      "Edward M. Lerner"
+    ],
+    "duration": 10.000,
+    "identifier": "urn:librarysimplified.org/terms/id/Bibliotheca%20ID/eb517g9",
+    "@type": "http://bib.schema.org/Audiobook"
+  }
+}


### PR DESCRIPTION
**What's this do?**

This modifies the code that parses manifests so that text starting with "0" is parsed into a string instead of an int.

This is sort of a hack, but trying to guess the appropriate type of a property in the first place is sort of a hack, so I refuse to feel bad about it.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes an error that could happen with findaway audiobooks. If the `findaway:fullfillmentId` property in the `encrypted` section of the manifest started with "0", it was parsed into an int, then converted back to a string, resulting in the leading "0" being lost. This incorrect ID was then sent to findaway APIs, causing an error.

Notion: https://www.notion.so/lyrasis/Error-code-51000-An-error-occurred-during-playback-on-Android-Audiobooks-db0d12b05e8f4d269011a776224b049a

**How should this be tested? / Do these changes have associated tests?**

I added a unit test, which now passes. All of the audiobooks specified in the notion ticket are no longer present in LYRASIS Reads library, so I'm not sure how to test it in the app at this point. Assuming we can find a different findaway audiobook with a fulfillment ID that starts with "0", it should play without error. Other audiobooks should also continue to play without error.

**Did someone actually run this code to verify it works?**
@ray-lee tested this when "Juggler of Worlds" still existed in LYRASIS Reads.
