### PR TITLE
Fixed audiobook playback rate incorrect behavior

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -143,15 +143,16 @@
         <c:change date="2021-11-19T00:00:00+00:00" summary="Enable dark mode"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-28T00:24:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
+    <c:release date="2022-01-22T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
-        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-22T06:15:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
-      <c:changes/>
+    <c:release date="2022-01-28T00:24:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
+      <c:changes>
+        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -143,10 +143,11 @@
         <c:change date="2021-11-19T00:00:00+00:00" summary="Enable dark mode"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-22T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
+    <c:release date="2022-01-28T00:24:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
+        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
       </c:changes>
     </c:release>
     <c:release date="2022-01-22T06:15:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -23,8 +23,7 @@ import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.joda.time.Duration
-import org.librarysimplified.audiobook.api.PlayerAudioBookType
-import org.librarysimplified.audiobook.api.PlayerEvent
+import org.librarysimplified.audiobook.api.*
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventError
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventManifestUpdated
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
@@ -36,14 +35,10 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
-import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerCancelled
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerFinished
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerRunning
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerStopped
-import org.librarysimplified.audiobook.api.PlayerSleepTimerType
-import org.librarysimplified.audiobook.api.PlayerSpineElementType
-import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityErrorOccurred
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsBuffering
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsWaitingForChapter
@@ -111,6 +106,7 @@ class PlayerFragment : Fragment() {
   private var playerBufferingTask: ScheduledFuture<*>? = null
   private var playerPositionDragging: Boolean = false
 
+  private var currentPlaybackRate: PlayerPlaybackRate = PlayerPlaybackRate.NORMAL_TIME
   private var playerPositionCurrentSpine: PlayerSpineElementType? = null
   private var playerPositionCurrentOffset: Long = 0L
   private var playerEventSubscription: Subscription? = null
@@ -642,6 +638,7 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
+        this.currentPlaybackRate = this.player.playbackRate
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
@@ -689,6 +686,7 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
+        this.player.playbackRate = this.currentPlaybackRate
         this.playPauseButton.setImageResource(R.drawable.pause_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPause() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_pause)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -23,7 +23,8 @@ import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.joda.time.Duration
-import org.librarysimplified.audiobook.api.*
+import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventError
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventManifestUpdated
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
@@ -35,10 +36,15 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerPlaybackRate
+import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerCancelled
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerFinished
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerRunning
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerStopped
+import org.librarysimplified.audiobook.api.PlayerSleepTimerType
+import org.librarysimplified.audiobook.api.PlayerSpineElementType
+import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityErrorOccurred
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsBuffering
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsWaitingForChapter


### PR DESCRIPTION
**What's this do?**
This PR adds logic to locally store the current playback rate speed to prevent it from being reset when the user pauses and plays some audiobook players.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [an issue](https://www.notion.so/lyrasis/2x-playback-speed-does-not-work-correctly-sometimes-98f21575c8af4cceaa665cd835f3eb26) that says that in some players, if the user changes the playback rate and pauses the audiobook, the playback rate will be reset when he resumes it again. This is an unwanted behavior as the user wants to keep the previously selected playback rate.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Selected "Lyrasis Reads" library
Get "Down the Hatch" audiobook
Tap on "Listen" button
Click on"Play" button
Open the playback rate settings and select "2x"
Click on "Pause" button
Click on "Play" button
Verify the audiobook's playback rate is still on 2x

**Did someone actually run this code to verify it works?**
Tested by @nunommts