### PR TITLE
Fix crash when exiting audiobook

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -143,15 +143,16 @@
         <c:change date="2021-11-19T00:00:00+00:00" summary="Enable dark mode"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-28T00:24:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
+    <c:release date="2022-01-22T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
-        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-22T06:15:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
-      <c:changes/>
+    <c:release date="2022-01-28T00:24:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
+      <c:changes>
+        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -143,10 +143,11 @@
         <c:change date="2021-11-19T00:00:00+00:00" summary="Enable dark mode"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-22T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
+    <c:release date="2022-01-28T00:24:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="6.10.0">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
+        <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
       </c:changes>
     </c:release>
     <c:release date="2022-01-22T06:15:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -149,9 +149,10 @@
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-28T00:24:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
+    <c:release date="2022-02-02T15:53:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.1">
       <c:changes>
         <c:change date="2022-01-28T00:24:00+00:00" summary="Fixed audiobook playback rate incorrect behavior"/>
+        <c:change date="2022-02-02T15:53:44+00:00" summary="Fixed crash when exiting an audiobook"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -140,7 +140,7 @@ class PlayerFragment : Fragment() {
 
     this.parameters =
       this.arguments!!.getSerializable(parametersKey)
-      as PlayerFragmentParameters
+        as PlayerFragmentParameters
     this.timeStrings =
       PlayerTimeStrings.SpokenTranslations.createFromResources(this.resources)
   }
@@ -198,10 +198,12 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
-        this.menuSleepText.text = ""
-        this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
-        this.menuSleepText.visibility = INVISIBLE
-        this.menuSleepEndOfChapter.visibility = INVISIBLE
+        safelyPerformOperations {
+          this.menuSleepText.text = ""
+          this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepEndOfChapter.visibility = INVISIBLE
+        }
       }
     )
   }
@@ -209,10 +211,12 @@ class PlayerFragment : Fragment() {
   private fun onPlayerSleepTimerEventCancelled() {
     UIThread.runOnUIThread(
       Runnable {
-        this.menuSleepText.text = ""
-        this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
-        this.menuSleepText.visibility = INVISIBLE
-        this.menuSleepEndOfChapter.visibility = INVISIBLE
+        safelyPerformOperations {
+          this.menuSleepText.text = ""
+          this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepEndOfChapter.visibility = INVISIBLE
+        }
       }
     )
   }
@@ -220,21 +224,23 @@ class PlayerFragment : Fragment() {
   private fun onPlayerSleepTimerEventRunning(event: PlayerSleepTimerRunning) {
     UIThread.runOnUIThread(
       Runnable {
-        val remaining = event.remaining
-        if (remaining != null) {
-          this.menuSleep.actionView.contentDescription =
-            this.sleepTimerContentDescriptionForTime(event.paused, remaining)
-          this.menuSleepText.text =
-            PlayerTimeStrings.minuteSecondTextFromDuration(remaining)
-          this.menuSleepEndOfChapter.visibility = INVISIBLE
-        } else {
-          this.menuSleep.actionView.contentDescription =
-            this.sleepTimerContentDescriptionEndOfChapter()
-          this.menuSleepText.text = ""
-          this.menuSleepEndOfChapter.visibility = VISIBLE
-        }
+        safelyPerformOperations {
+          val remaining = event.remaining
+          if (remaining != null) {
+            this.menuSleep.actionView.contentDescription =
+              this.sleepTimerContentDescriptionForTime(event.paused, remaining)
+            this.menuSleepText.text =
+              PlayerTimeStrings.minuteSecondTextFromDuration(remaining)
+            this.menuSleepEndOfChapter.visibility = INVISIBLE
+          } else {
+            this.menuSleep.actionView.contentDescription =
+              this.sleepTimerContentDescriptionEndOfChapter()
+            this.menuSleepText.text = ""
+            this.menuSleepEndOfChapter.visibility = VISIBLE
+          }
 
-        this.menuSleepText.visibility = VISIBLE
+          this.menuSleepText.visibility = VISIBLE
+        }
       }
     )
   }
@@ -282,17 +288,24 @@ class PlayerFragment : Fragment() {
     builder.append(". ")
     builder.append(this.resources.getString(R.string.audiobook_accessibility_playback_speed_currently))
     builder.append(" ")
-    builder.append(PlayerPlaybackRateAdapter.contentDescriptionOfRate(this.resources, this.player.playbackRate))
+    builder.append(
+      PlayerPlaybackRateAdapter.contentDescriptionOfRate(
+        this.resources,
+        this.player.playbackRate
+      )
+    )
     return builder.toString()
   }
 
   private fun onPlayerSleepTimerEventStopped() {
     UIThread.runOnUIThread(
       Runnable {
-        this.menuSleepText.text = ""
-        this.menuSleepText.contentDescription = this.sleepTimerContentDescriptionSetUp()
-        this.menuSleepText.visibility = INVISIBLE
-        this.menuSleepEndOfChapter.visibility = INVISIBLE
+        safelyPerformOperations {
+          this.menuSleepText.text = ""
+          this.menuSleepText.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepEndOfChapter.visibility = INVISIBLE
+        }
       }
     )
   }
@@ -490,7 +503,7 @@ class PlayerFragment : Fragment() {
     if (spine != null) {
       val target = spine.position.copy(
         offsetMilliseconds =
-          TimeUnit.MILLISECONDS.convert(this.playerPosition.progress.toLong(), TimeUnit.SECONDS)
+        TimeUnit.MILLISECONDS.convert(this.playerPosition.progress.toLong(), TimeUnit.SECONDS)
       )
       if (this.player.isPlaying) {
         this.player.playAtLocation(target)
@@ -552,24 +565,28 @@ class PlayerFragment : Fragment() {
 
   private fun onPlayerEventCreateBookmark() {
     UIThread.runOnUIThread {
-      this.playerBookmark.alpha = 0.5f
-      this.playerBookmark.animation =
-        AnimationUtils.loadAnimation(this.context, R.anim.zoom_fade)
+      safelyPerformOperations {
+        this.playerBookmark.alpha = 0.5f
+        this.playerBookmark.animation =
+          AnimationUtils.loadAnimation(this.context, R.anim.zoom_fade)
+      }
     }
   }
 
   private fun onPlayerEventError(event: PlayerEventError) {
     UIThread.runOnUIThread(
       Runnable {
-        val text = this.getString(R.string.audiobook_player_error, event.errorCode)
-        this.playerWaiting.setText(text)
-        this.playerWaiting.contentDescription = null
-        this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityErrorOccurred(text))
+        safelyPerformOperations {
+          val text = this.getString(R.string.audiobook_player_error, event.errorCode)
+          this.playerWaiting.setText(text)
+          this.playerWaiting.contentDescription = null
+          this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityErrorOccurred(text))
 
-        val element = event.spineElement
-        if (element != null) {
-          this.configureSpineElementText(element, isPlaying = false)
-          this.onEventUpdateTimeRelatedUI(element, event.offsetMilliseconds)
+          val element = event.spineElement
+          if (element != null) {
+            this.configureSpineElementText(element, isPlaying = false)
+            this.onEventUpdateTimeRelatedUI(element, event.offsetMilliseconds)
+          }
         }
       }
     )
@@ -578,14 +595,16 @@ class PlayerFragment : Fragment() {
   private fun onPlayerEventChapterWaiting(event: PlayerEventChapterWaiting) {
     UIThread.runOnUIThread(
       Runnable {
-        val text =
-          this.getString(R.string.audiobook_player_waiting, event.spineElement.index + 1)
-        this.playerWaiting.setText(text)
-        this.playerWaiting.contentDescription = null
-        this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityIsWaitingForChapter(text))
+        safelyPerformOperations {
+          val text =
+            this.getString(R.string.audiobook_player_waiting, event.spineElement.index + 1)
+          this.playerWaiting.setText(text)
+          this.playerWaiting.contentDescription = null
+          this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityIsWaitingForChapter(text))
 
-        this.configureSpineElementText(event.spineElement, isPlaying = false)
-        this.onEventUpdateTimeRelatedUI(event.spineElement, 0)
+          this.configureSpineElementText(event.spineElement, isPlaying = false)
+          this.onEventUpdateTimeRelatedUI(event.spineElement, 0)
+        }
       }
     )
   }
@@ -593,9 +612,11 @@ class PlayerFragment : Fragment() {
   private fun onPlayerEventPlaybackBuffering(event: PlayerEventPlaybackBuffering) {
     UIThread.runOnUIThread(
       Runnable {
-        this.onPlayerBufferingStarted()
-        this.configureSpineElementText(event.spineElement, isPlaying = false)
-        this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        safelyPerformOperations {
+          this.onPlayerBufferingStarted()
+          this.configureSpineElementText(event.spineElement, isPlaying = false)
+          this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        }
       }
     )
   }
@@ -619,9 +640,12 @@ class PlayerFragment : Fragment() {
   private fun onPlayerEventPlaybackRateChanged(event: PlayerEventPlaybackRateChanged) {
     UIThread.runOnUIThread(
       Runnable {
-        this.currentPlaybackRate = event.rate
-        this.menuPlaybackRateText.text = PlayerPlaybackRateAdapter.textOfRate(event.rate)
-        this.menuPlaybackRate.actionView.contentDescription = this.playbackRateContentDescription()
+        safelyPerformOperations {
+          this.currentPlaybackRate = event.rate
+          this.menuPlaybackRateText.text = PlayerPlaybackRateAdapter.textOfRate(event.rate)
+          this.menuPlaybackRate.actionView.contentDescription =
+            this.playbackRateContentDescription()
+        }
       }
     )
   }
@@ -633,7 +657,8 @@ class PlayerFragment : Fragment() {
       Runnable {
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
-        this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
+        this.playPauseButton.contentDescription =
+          this.getString(R.string.audiobook_accessibility_play)
         this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
       }
@@ -645,12 +670,15 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
-        this.currentPlaybackRate = this.player.playbackRate
-        this.playPauseButton.setImageResource(R.drawable.play_icon)
-        this.playPauseButton.setOnClickListener { this.onPressedPlay() }
-        this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
-        this.configureSpineElementText(event.spineElement, isPlaying = false)
-        this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        safelyPerformOperations {
+          this.currentPlaybackRate = this.player.playbackRate
+          this.playPauseButton.setImageResource(R.drawable.play_icon)
+          this.playPauseButton.setOnClickListener { this.onPressedPlay() }
+          this.playPauseButton.contentDescription =
+            this.getString(R.string.audiobook_accessibility_play)
+          this.configureSpineElementText(event.spineElement, isPlaying = false)
+          this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        }
       }
     )
   }
@@ -673,17 +701,30 @@ class PlayerFragment : Fragment() {
     this.playerService.updatePlayerInfo(this.playerInfoModel)
   }
 
+  private fun safelyPerformOperations(operations: () -> Unit) {
+
+    // if the fragment is not attached anymore, we can't perform the operations. This may occur due
+    //to a racing condition
+    if (!this.isAdded) {
+      return
+    }
+
+    operations()
+  }
+
   private fun onPlayerEventPlaybackProgressUpdate(event: PlayerEventPlaybackProgressUpdate) {
     this.onPlayerBufferingStopped()
-
     UIThread.runOnUIThread(
       Runnable {
-        this.playPauseButton.setImageResource(R.drawable.pause_icon)
-        this.playPauseButton.setOnClickListener { this.onPressedPause() }
-        this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_pause)
-        this.playerWaiting.text = ""
-        this.playerWaiting.contentDescription = null
-        this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        safelyPerformOperations {
+          this.playPauseButton.setImageResource(R.drawable.pause_icon)
+          this.playPauseButton.setOnClickListener { this.onPressedPause() }
+          this.playPauseButton.contentDescription =
+            this.getString(R.string.audiobook_accessibility_pause)
+          this.playerWaiting.text = ""
+          this.playerWaiting.contentDescription = null
+          this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        }
       }
     )
   }
@@ -693,14 +734,17 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
-        this.player.playbackRate = this.currentPlaybackRate
-        this.playPauseButton.setImageResource(R.drawable.pause_icon)
-        this.playPauseButton.setOnClickListener { this.onPressedPause() }
-        this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_pause)
-        this.configureSpineElementText(event.spineElement, isPlaying = true)
-        this.playerPosition.isEnabled = true
-        this.playerWaiting.text = ""
-        this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        safelyPerformOperations {
+          this.player.playbackRate = this.currentPlaybackRate
+          this.playPauseButton.setImageResource(R.drawable.pause_icon)
+          this.playPauseButton.setOnClickListener { this.onPressedPause() }
+          this.playPauseButton.contentDescription =
+            this.getString(R.string.audiobook_accessibility_pause)
+          this.configureSpineElementText(event.spineElement, isPlaying = true)
+          this.playerPosition.isEnabled = true
+          this.playerWaiting.text = ""
+          this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)
+        }
       }
     )
   }
@@ -774,8 +818,7 @@ class PlayerFragment : Fragment() {
     offsetMilliseconds: Long,
     duration: Duration?
   ): String {
-    return duration?.let {
-      time ->
+    return duration?.let { time ->
       this.playerTimeRemainingSpoken(offsetMilliseconds, time)
     } ?: ""
   }
@@ -848,10 +891,12 @@ class PlayerFragment : Fragment() {
   private fun onPlayerBufferingStarted() {
     UIThread.runOnUIThread(
       Runnable {
-        this.onPlayerBufferingStopTaskNow()
-        this.playerBufferingStillOngoing = true
-        this.playerBufferingTask =
-          this.executor.schedule({ this.onPlayerBufferingCheckNow() }, 2L, TimeUnit.SECONDS)
+        safelyPerformOperations {
+          this.onPlayerBufferingStopTaskNow()
+          this.playerBufferingStillOngoing = true
+          this.playerBufferingTask =
+            this.executor.schedule({ this.onPlayerBufferingCheckNow() }, 2L, TimeUnit.SECONDS)
+        }
       }
     )
   }
@@ -859,12 +904,19 @@ class PlayerFragment : Fragment() {
   private fun onPlayerBufferingCheckNow() {
     UIThread.runOnUIThread(
       Runnable {
-        if (this.playerBufferingStillOngoing) {
-          val accessibleMessage = this.getString(R.string.audiobook_accessibility_player_buffering)
-          this.playerWaiting.contentDescription = accessibleMessage
-          this.playerWaiting.setText(R.string.audiobook_player_buffering)
-          this.playerWaiting.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
-          this.listener.onPlayerAccessibilityEvent(PlayerAccessibilityIsBuffering(accessibleMessage))
+        safelyPerformOperations {
+          if (this.playerBufferingStillOngoing) {
+            val accessibleMessage =
+              this.getString(R.string.audiobook_accessibility_player_buffering)
+            this.playerWaiting.contentDescription = accessibleMessage
+            this.playerWaiting.setText(R.string.audiobook_player_buffering)
+            this.playerWaiting.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
+            this.listener.onPlayerAccessibilityEvent(
+              PlayerAccessibilityIsBuffering(
+                accessibleMessage
+              )
+            )
+          }
         }
       }
     )
@@ -873,8 +925,10 @@ class PlayerFragment : Fragment() {
   private fun onPlayerBufferingStopped() {
     UIThread.runOnUIThread(
       Runnable {
-        this.onPlayerBufferingStopTaskNow()
-        this.playerBufferingStillOngoing = false
+        safelyPerformOperations {
+          this.onPlayerBufferingStopTaskNow()
+          this.playerBufferingStillOngoing = false
+        }
       }
     )
   }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -619,6 +619,7 @@ class PlayerFragment : Fragment() {
   private fun onPlayerEventPlaybackRateChanged(event: PlayerEventPlaybackRateChanged) {
     UIThread.runOnUIThread(
       Runnable {
+        this.currentPlaybackRate = event.rate
         this.menuPlaybackRateText.text = PlayerPlaybackRateAdapter.textOfRate(event.rate)
         this.menuPlaybackRate.actionView.contentDescription = this.playbackRateContentDescription()
       }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -23,8 +23,7 @@ import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.joda.time.Duration
-import org.librarysimplified.audiobook.api.PlayerAudioBookType
-import org.librarysimplified.audiobook.api.PlayerEvent
+import org.librarysimplified.audiobook.api.*
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventError
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventManifestUpdated
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
@@ -36,14 +35,10 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
-import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerCancelled
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerFinished
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerRunning
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerStopped
-import org.librarysimplified.audiobook.api.PlayerSleepTimerType
-import org.librarysimplified.audiobook.api.PlayerSpineElementType
-import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityErrorOccurred
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsBuffering
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsWaitingForChapter
@@ -111,6 +106,7 @@ class PlayerFragment : Fragment() {
   private var playerBufferingTask: ScheduledFuture<*>? = null
   private var playerPositionDragging: Boolean = false
 
+  private var currentPlaybackRate: PlayerPlaybackRate = PlayerPlaybackRate.NORMAL_TIME
   private var playerPositionCurrentSpine: PlayerSpineElementType? = null
   private var playerPositionCurrentOffset: Long = 0L
   private var playerEventSubscription: Subscription? = null
@@ -642,6 +638,7 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
+        this.currentPlaybackRate = this.player.playbackRate
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_play)
@@ -689,6 +686,7 @@ class PlayerFragment : Fragment() {
 
     UIThread.runOnUIThread(
       Runnable {
+        this.player.playbackRate = this.currentPlaybackRate
         this.playPauseButton.setImageResource(R.drawable.pause_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPause() }
         this.playPauseButton.contentDescription = this.getString(R.string.audiobook_accessibility_pause)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -658,7 +658,6 @@ class PlayerFragment : Fragment() {
         this.playPauseButton.setImageResource(R.drawable.play_icon)
         this.playPauseButton.setOnClickListener { this.onPressedPlay() }
         this.playPauseButton.contentDescription =
-
           this.getString(R.string.audiobook_accessibility_play)
         this.configureSpineElementText(event.spineElement, isPlaying = false)
         this.onEventUpdateTimeRelatedUI(event.spineElement, event.offsetMilliseconds)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -23,7 +23,8 @@ import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.joda.time.Duration
-import org.librarysimplified.audiobook.api.*
+import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventError
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventManifestUpdated
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
@@ -35,10 +36,15 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerPlaybackRate
+import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerCancelled
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerFinished
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerRunning
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTimerStopped
+import org.librarysimplified.audiobook.api.PlayerSleepTimerType
+import org.librarysimplified.audiobook.api.PlayerSpineElementType
+import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityErrorOccurred
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsBuffering
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsWaitingForChapter


### PR DESCRIPTION
**What's this do?**
This PR adds logic to verify if the _PlayerFragment_ is still added to the activity so the app can perform some operations with its context.

**Why are we doing this? (w/ JIRA link if applicable)**
[An issue was related](https://www.notion.so/lyrasis/Android-crash-when-exiting-audiobook-player-while-book-is-playing-9f0fc1db7cee4ea792901eddf6685a64) saying that sometimes the app crashes when the user is listening to an audiobook and tries to return to the previous screen.

**How should this be tested? / Do these changes have associated tests?**
This does not happen every time, but the steps are:

1. Start playing an audiobook, e.g. "Daughter of the Morning Star” or “The List” on Lyrasis Reads (but it probably doesn’t matter which book).
2. While the book is playing, tap the back button in the toolbar.
3. Verify everything's ok and the app didn't crash

**Did someone actually run this code to verify it works?**
Tested by @nunommts