### PR TITLE
Changed displaying title for audiobook chapters with no or null title

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -156,9 +156,10 @@
         <c:change date="2022-02-15T00:00:00+00:00" summary="Added dimension ratio to audiobook cover image"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-13T05:25:07+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.2">
+    <c:release date="2022-03-22T14:27:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.10.2">
       <c:changes>
-        <c:change date="2022-03-13T05:25:07+00:00" summary="Added support for LCP-protected audio books."/>
+        <c:change date="2022-03-13T00:00:00+00:00" summary="Added support for LCP-protected audio books."/>
+        <c:change date="2022-03-22T14:27:52+00:00" summary="Changed displaying title for audiobook chapters with no or null title"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -825,7 +825,7 @@ class PlayerFragment : Fragment() {
 
   private fun spineElementText(spineElement: PlayerSpineElementType): String {
     val title = spineElement.title ?: this.getString(
-      R.string.audiobook_player_toc_chapter_n,
+      R.string.audiobook_player_toc_track_n,
       spineElement.index + 1
     )
 
@@ -857,7 +857,7 @@ class PlayerFragment : Fragment() {
     }
 
     val accessibilityTitle = element.title ?: this.getString(
-      R.string.audiobook_accessibility_toc_chapter_n,
+      R.string.audiobook_accessibility_toc_track_n,
       element.index + 1
     )
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -79,7 +79,7 @@ class PlayerTOCAdapter(
     val normalIndex = item.index + 1
 
     val title = item.title ?: this.context.getString(
-      R.string.audiobook_player_toc_chapter_n,
+      R.string.audiobook_player_toc_track_n,
       normalIndex
     )
 

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
   <string name="audiobook_player_waiting">File %1$d must be downloaded to continue playback.</string>
   <string name="audiobook_player_error">An error occurred during playback. Error code: %1$d</string>
 
-  <string name="audiobook_player_toc_chapter_n">Chapter %1$d</string>
+  <string name="audiobook_player_toc_track_n">Track %1$d</string>
   <string name="audiobook_player_toc_menu_refresh_all">Refresh All</string>
   <string name="audiobook_player_toc_menu_stop_all">Stop All Downloads</string>
   <string name="audiobook_player_toc_menu_stop_all_confirm">Stop all downloads?</string>
@@ -102,7 +102,7 @@
   <string name="audiobook_accessibility_pause">Pause</string>
   <string name="audiobook_accessibility_book_cover">Book cover</string>
 
-  <string name="audiobook_accessibility_toc_chapter_n">Chapter %1$d</string>
+  <string name="audiobook_accessibility_toc_track_n">Track %1$d</string>
   <string name="audiobook_accessibility_toc_chapter_is_current">Selected</string>
   <string name="audiobook_accessibility_toc_chapter_requires_download">File Must Be Downloaded Before It Can Be Played</string>
   <string name="audiobook_accessibility_toc_chapter_failed_download">File Has Failed To Download</string>


### PR DESCRIPTION
**What's this do?**
This PR changes the text to display when an audiobook chapter has no title or its title is null

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Change-display-for-null-missing-audiobook-track-titles-from-Chapter-to-Track-Android-0b73709c43da4f18a6a6047cf143e4f2) to update the text to prevent a possible confusion to be created when navigating in the table of contents page

**How should this be tested? / Do these changes have associated tests?**
I wasn't able to test this because I didn't find any audiobook with null chapter titles, but there may be something in [this ticket](https://www.notion.so/3189d802ade84ffa903ab4c77563e2d2)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No