### PR TITLE
Make scope, client key, and client secret optional for OverDrive

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -162,8 +162,10 @@
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed displaying title for audiobook chapters with no or null title"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-29T17:14:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.11.1">
-      <c:changes/>
+    <c:release date="2022-03-31T15:02:48+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.11.1">
+      <c:changes>
+        <c:change date="2022-03-31T15:02:48+00:00" summary="Make scope, client key, and client secret optional for OverDrive downloads."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.audiobook.manifest_fulfill.opa/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/opa/OPAManifestURI.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.opa/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/opa/OPAManifestURI.kt
@@ -16,7 +16,7 @@ sealed class OPAManifestURI {
 
   data class Direct(
     val targetURI: URI,
-    val scope: String
+    val scope: String? = null,
   ) : OPAManifestURI()
 
   /**

--- a/org.librarysimplified.audiobook.manifest_fulfill.opa/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/opa/OPAParameters.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.opa/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/opa/OPAParameters.kt
@@ -12,8 +12,8 @@ import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentS
 data class OPAParameters(
   val userName: String,
   val password: OPAPassword,
-  val clientKey: String,
-  val clientPass: String,
+  val clientKey: String?,
+  val clientPass: String?,
   val targetURI: OPAManifestURI,
   override val userAgent: PlayerUserAgent
 ) : ManifestFulfillmentStrategyParametersType


### PR DESCRIPTION
**What's this do?**
This makes the OverDrive scope, client key, and client secret optional (nullable) for OverDrive downloads.

The CM will be changed to supply the OverDrive patron token in the initial fulfillment request, so these will become unnecessary.

**Why are we doing this? (w/ JIRA link if applicable)**

This allows us to remove the OverDrive client key and secret from the app, to improve security. Notion: https://www.notion.so/lyrasis/Android-Remove-need-for-OverDrive-client-key-and-secret-fbf7cf563def446dbb501fb7bcfa3a5a

**How should this be tested? / Do these changes have associated tests?**

This can't be tested on its own, but follow-on PRs in android-audiobook-overdrive and android-core will have unit tests and be end-user testable.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this along with upcoming PRs to android-audiobook-overdrive and android-core.
