### PR TITLE
Make demo app initiate downloads when opening an audiobook.

### DIFF
--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -540,6 +540,8 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     this.player.movePlayheadToLocation(lastPlayed)
     this.playerEvents = this.player.events.subscribe(this::onPlayerEvent)
 
+    this.startAllPartsDownloading()
+
     /*
      * Create and load the main player fragment into the holder view declared in the activity.
      */
@@ -554,6 +556,10 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
           .commit()
       }
     )
+  }
+
+  private fun startAllPartsDownloading() {
+    this.book.wholeBookDownloadTask.fetch()
   }
 
   /**


### PR DESCRIPTION
**What's this do?**

This makes the demo app initiate downloads of audio files when it opens, so that audio will play. It is based on code from AudioBookPlayerActivity in android-core: https://github.com/ThePalaceProject/android-core/blob/a9900487f7cf5d119b45ccdbbafd31301b4af3d7/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt#L411

**Why are we doing this? (w/ JIRA link if applicable)**

Being able to download and play audiobooks in the demo player is useful for debugging.

**How should this be tested? / Do these changes have associated tests?**

Run the demo app. Select the Flatland book, and open it. Tap the play button. The book should start playing. Tap the TOC icon. The chapters should indicate that they are downloaded, or are downloading.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

No, this is not a user-facing change.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee played Flatland in the demo app.

