### PR TITLE
Removed padding from audiobook cover image

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -162,9 +162,10 @@
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed displaying title for audiobook chapters with no or null title"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-31T15:02:48+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.11.1">
+    <c:release date="2022-04-13T09:37:50+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.11.1">
       <c:changes>
-        <c:change date="2022-03-31T15:02:48+00:00" summary="Make scope, client key, and client secret optional for OverDrive downloads."/>
+        <c:change date="2022-03-31T00:00:00+00:00" summary="Make scope, client key, and client secret optional for OverDrive downloads."/>
+        <c:change date="2022-04-13T09:37:50+00:00" summary="Removed padding from audiobook cover image"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -112,11 +112,11 @@
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/audiobook_accessibility_play"
         android:src="@drawable/play_icon"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:tint="?attr/simplifiedColorControlIcon"
+        app:tintMode="src_in" />
 
     <ImageView
         android:id="@+id/player_jump_backwards"
@@ -126,11 +126,11 @@
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/audiobook_accessibility_backward_15"
         android:src="@drawable/circle_arrow_backward"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/player_play_button"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:tint="?attr/simplifiedColorControlIcon"
+        app:tintMode="src_in" />
 
     <TextView
         android:id="@+id/player_jump_forwards_text"
@@ -141,9 +141,9 @@
         android:gravity="center"
         android:importantForAccessibility="no"
         android:text="@string/audiobook_player_seek_15"
+        android:textColor="?attr/simplifiedColorControlIcon"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:textColor="?attr/simplifiedColorControlIcon"
         app:layout_constraintBottom_toBottomOf="@id/player_jump_forwards"
         app:layout_constraintEnd_toEndOf="@id/player_jump_forwards"
         app:layout_constraintStart_toStartOf="@id/player_jump_forwards"
@@ -157,11 +157,11 @@
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/audiobook_accessibility_forward_15"
         android:src="@drawable/circle_arrow_forward"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/player_play_button" />
+        app:layout_constraintStart_toEndOf="@id/player_play_button"
+        app:tint="?attr/simplifiedColorControlIcon"
+        app:tintMode="src_in" />
 
     <TextView
         android:id="@+id/player_jump_backwards_text"
@@ -172,9 +172,9 @@
         android:gravity="center"
         android:importantForAccessibility="no"
         android:text="@string/audiobook_player_seek_15"
+        android:textColor="?attr/simplifiedColorControlIcon"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:textColor="?attr/simplifiedColorControlIcon"
         app:layout_constraintBottom_toBottomOf="@id/player_jump_backwards"
         app:layout_constraintEnd_toEndOf="@id/player_jump_backwards"
         app:layout_constraintStart_toStartOf="@id/player_jump_backwards"
@@ -199,17 +199,14 @@
         android:id="@+id/player_cover"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_margin="16dp"
         android:contentDescription="@string/audiobook_accessibility_book_cover"
+        android:scaleType="centerCrop"
         android:src="@drawable/icon"
-        app:layout_constraintDimensionRatio="H,3:4"
         app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_time" />
+        app:layout_constraintTop_toBottomOf="@id/player_spine_element" />
 
     <ImageView
         android:id="@+id/player_bookmark"


### PR DESCRIPTION
**What's this do?**
This PR adds a _scaleType_ value to the audiobook player xml file in order to properly adjust the image dimensions to the available space. There's also a change in the code to the image margins and constraints so the elements are better organized

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Remove-padding-from-audiobook-covers-in-audiobook-player-978d53cc75ed40e790a49793d7af97ce) to make the image similar to the iOS version where there are no padding in the image

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "LYRASIS Reads" Library
Search for "Down the Hatch"
Open it
Verify the image [has no padding](https://user-images.githubusercontent.com/79104027/163150452-a0fd59a1-cd4f-47cc-9692-cd9a29bbcde5.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 