### PR TITLE
Updated audiobook chapter/tracks downloading logic

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,8 +175,10 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-04-29T13:16:20+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
-      <c:changes/>
+    <c:release date="2022-05-02T16:57:34+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+      <c:changes>
+        <c:change date="2022-05-02T16:57:34+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioBookType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioBookType.kt
@@ -46,6 +46,11 @@ interface PlayerAudioBookType : Closeable {
   val spine: List<PlayerSpineElementType>
 
   /**
+   * The list of download tasks for each available audiobook file.
+   */
+  val downloadTasks: List<PlayerDownloadTaskType>
+
+  /**
    * The spine items organized by their unique IDs.
    */
 

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerDownloadTaskType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerDownloadTaskType.kt
@@ -31,6 +31,12 @@ interface PlayerDownloadTaskType {
   fun delete()
 
   /**
+   * Checks if a specific spine element belongs to this task's spine items list.
+   */
+
+  fun fulfillsSpineElement(spineElement: PlayerSpineElementType): Boolean
+
+  /**
    * The current download progress in the range [0, 1]
    */
 

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerDownloadTaskType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerDownloadTaskType.kt
@@ -35,4 +35,10 @@ interface PlayerDownloadTaskType {
    */
 
   val progress: Double
+
+  /**
+   * The list of spine items related to the download task.
+   */
+
+  val spineItems: List<PlayerSpineElementType>
 }

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSpineElementType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSpineElementType.kt
@@ -73,13 +73,4 @@ interface PlayerSpineElementType {
    */
 
   val downloadTasksSupported: Boolean
-
-  /**
-   * The download task for the spine item.
-   *
-   * @see downloadTasksSupported
-   */
-
-  @Throws(UnsupportedOperationException::class)
-  fun downloadTask(): PlayerDownloadTaskType
 }

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
@@ -3,10 +3,10 @@ package org.librarysimplified.audiobook.lcp
 import android.content.Context
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.SettableFuture
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
+import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
@@ -66,6 +66,7 @@ class LCPAudioBook private constructor(
     override fun cancel() {}
     override fun delete() {}
     override val progress = 1.0
+    override val spineItems = listOf<PlayerSpineElementType>()
   }
 
   override fun replaceManifest(
@@ -177,6 +178,9 @@ class LCPAudioBook private constructor(
       this.spineElementDownloadStatus.onCompleted()
     }
   }
+
+  override val downloadTasks: List<PlayerDownloadTaskType>
+    get() = emptyList()
 
   override val isClosed: Boolean
     get() = this.isClosedNow.get()

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
@@ -67,6 +67,7 @@ class LCPAudioBook private constructor(
     override fun delete() {}
     override val progress = 1.0
     override val spineItems = listOf<PlayerSpineElementType>()
+    override fun fulfillsSpineElement(spineElement: PlayerSpineElementType) = false
   }
 
   override fun replaceManifest(

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPSpineElement.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPSpineElement.kt
@@ -49,23 +49,6 @@ class LCPSpineElement(
   override val title: String?
     get() = this.itemManifest.title
 
-  /**
-   * LCP-protected books are packaged, so the whole book will have been downloaded before being
-   * handed to the player. This downloadTask simply no-ops all of its methods, and reports that
-   * download is complete.
-   */
-
-  private val downloadTask = object : PlayerDownloadTaskType {
-    override fun fetch() {}
-    override fun cancel() {}
-    override fun delete() {}
-    override val progress = 1.0
-  }
-
-  override fun downloadTask(): PlayerDownloadTaskType {
-    return this.downloadTask
-  }
-
   fun setBook(book: LCPAudioBook) {
     this.bookActual = book
   }

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
@@ -6,6 +6,7 @@ import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
@@ -64,6 +65,9 @@ class MockingAudioBook(
 
   override val spineElementDownloadStatus: Observable<PlayerSpineElementDownloadStatus>
     get() = this.statusEvents
+
+  override val downloadTasks: List<PlayerDownloadTaskType>
+    get() = listOf(this.wholeTask)
 
   override val wholeBookDownloadTask: PlayerDownloadWholeBookTaskType
     get() = this.wholeTask

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
@@ -37,8 +37,6 @@ class MockingAudioBook(
   fun createSpineElement(id: String, title: String, duration: Duration): MockingSpineElement {
     val element = MockingSpineElement(
       bookMocking = this,
-      downloadProvider = this.downloadProvider,
-      downloadStatusExecutor = this.downloadStatusExecutor,
       downloadStatusEvents = this.statusEvents,
       index = spineItems.size,
       duration = duration,
@@ -47,6 +45,14 @@ class MockingAudioBook(
     )
     this.spineItems.add(element)
     return element
+  }
+
+  fun createDownloadTask(elements: List<MockingSpineElement>): MockingDownloadTask {
+    return MockingDownloadTask(
+      downloadStatusExecutor = this.downloadStatusExecutor,
+      downloadProvider = this.downloadProvider,
+      spineElements = elements
+    )
   }
 
   override var supportsStreaming: Boolean = false

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadTask.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadTask.kt
@@ -12,12 +12,12 @@ import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.Play
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementNotDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
-import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutorService
+import kotlin.random.Random
 
 /**
  * A fake download task.
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutorService
 class MockingDownloadTask(
   private val downloadStatusExecutor: ExecutorService,
   private val downloadProvider: PlayerDownloadProviderType,
-  private val originalLink: PlayerManifestLink,
   private val spineElements: List<MockingSpineElement>
 ) : PlayerDownloadTaskType {
 
@@ -87,7 +86,7 @@ class MockingDownloadTask(
     val future =
       this.downloadProvider.download(
         PlayerDownloadRequest(
-          uri = URI.create("urn:" + this.originalLink.toString()),
+          uri = URI.create("urn:" + Random.nextInt()),
           credentials = null,
           outputFile = File("/"),
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.mocking 1.0.0"),

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadTask.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadTask.kt
@@ -181,6 +181,10 @@ class MockingDownloadTask(
     }
   }
 
+  override fun fulfillsSpineElement(spineElement: PlayerSpineElementType): Boolean {
+    return spineElements.contains(spineElement)
+  }
+
   private fun onDeleteDownloading(state: State.Downloading) {
     this.log.debug("cancelling download in progress")
 

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadWholeBookTask.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadWholeBookTask.kt
@@ -29,6 +29,10 @@ class MockingDownloadWholeBookTask(
     }
   }
 
+  override fun fulfillsSpineElement(spineElement: PlayerSpineElementType): Boolean {
+    return spineItems.contains(spineElement)
+  }
+
   override val progress: Double
     get() = calculateProgress()
 

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadWholeBookTask.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingDownloadWholeBookTask.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.mocking
 
 import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
-import org.slf4j.LoggerFactory
+import org.librarysimplified.audiobook.api.PlayerSpineElementType
 
 /**
  * A fake download task.
@@ -11,24 +11,31 @@ class MockingDownloadWholeBookTask(
   private val audioBook: MockingAudioBook
 ) : PlayerDownloadWholeBookTaskType {
 
-  private val log = LoggerFactory.getLogger(MockingDownloadWholeBookTask::class.java)
-
   override fun fetch() {
-    this.audioBook.spine.map { item -> item.downloadTask().fetch() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.fetch()
+    }
   }
 
   override fun cancel() {
-    this.audioBook.spine.map { item -> item.downloadTask().cancel() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.cancel()
+    }
   }
 
   override fun delete() {
-    this.audioBook.spine.map { item -> item.downloadTask().delete() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.delete()
+    }
   }
 
   override val progress: Double
     get() = calculateProgress()
 
+  override val spineItems: List<PlayerSpineElementType>
+    get() = this.audioBook.spineItems
+
   private fun calculateProgress(): Double {
-    return this.audioBook.spine.sumByDouble { item -> item.downloadTask().progress } / this.audioBook.spine.size
+    return this.audioBook.downloadTasks.sumOf { task -> task.progress } / this.audioBook.downloadTasks.size
   }
 }

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
@@ -3,7 +3,6 @@ package org.librarysimplified.audiobook.mocking
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
@@ -62,15 +61,4 @@ class MockingSpineElement(
 
   override val downloadStatus: PlayerSpineElementDownloadStatus
     get() = this.downloadStatusValue
-
-  private val downloadTaskValue =
-    MockingDownloadTask(
-      downloadStatusExecutor = this.downloadStatusExecutor,
-      downloadProvider = this.downloadProvider,
-      spineElement = this
-    )
-
-  override fun downloadTask(): PlayerDownloadTaskType {
-    return this.downloadTaskValue
-  }
 }

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
@@ -2,12 +2,10 @@ package org.librarysimplified.audiobook.mocking
 
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
-import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import rx.subjects.BehaviorSubject
-import java.util.concurrent.ExecutorService
 
 /**
  * A fake spine element in a fake audio book.
@@ -15,8 +13,6 @@ import java.util.concurrent.ExecutorService
 
 class MockingSpineElement(
   val bookMocking: MockingAudioBook,
-  val downloadStatusExecutor: ExecutorService,
-  val downloadProvider: PlayerDownloadProviderType,
   val downloadStatusEvents: BehaviorSubject<PlayerSpineElementDownloadStatus>,
   override val index: Int,
   override val duration: Duration,

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -333,7 +333,7 @@ class ExoAudioBookPlayer private constructor(
       DefaultUriDataSource(this.context, null, this.userAgent)
 
     val uri =
-      Uri.fromFile(book.downloadTasks.first { it.isSpineElementFromList(spineElement) }.partFile)
+      Uri.fromFile(book.downloadTasks.first { it.fulfillsSpineElement(spineElement) }.partFile)
 
     val sampleSource =
       ExtractorSampleSource(

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -333,7 +333,7 @@ class ExoAudioBookPlayer private constructor(
       DefaultUriDataSource(this.context, null, this.userAgent)
 
     val uri =
-      Uri.fromFile(spineElement.partFile)
+      Uri.fromFile(book.downloadTasks.first { it.isSpineElementFromList(spineElement) }.partFile)
 
     val sampleSource =
       ExtractorSampleSource(

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
@@ -238,7 +238,7 @@ class ExoDownloadTask(
     }
   }
 
-  fun isSpineElementFromList(spineElement: ExoSpineElement): Boolean {
+  override fun fulfillsSpineElement(spineElement: PlayerSpineElementType): Boolean {
     return spineElements.contains(spineElement)
   }
 

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
@@ -12,6 +12,7 @@ import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.Play
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloading
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementNotDownloaded
+import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
 import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
@@ -19,6 +20,7 @@ import org.librarysimplified.audiobook.open_access.ExoDownloadTask.State.Downloa
 import org.librarysimplified.audiobook.open_access.ExoDownloadTask.State.Downloading
 import org.librarysimplified.audiobook.open_access.ExoDownloadTask.State.Initial
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.net.URI
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutorService
@@ -30,9 +32,11 @@ import java.util.concurrent.ExecutorService
 class ExoDownloadTask(
   private val downloadStatusExecutor: ExecutorService,
   private val downloadProvider: PlayerDownloadProviderType,
-  private val spineElement: ExoSpineElement,
+  private val originalLink: PlayerManifestLink,
+  private val spineElements: List<ExoSpineElement>,
   private val userAgent: PlayerUserAgent,
-  private val extensions: List<PlayerExtensionType>
+  private val extensions: List<PlayerExtensionType>,
+  val partFile: File
 ) : PlayerDownloadTaskType {
 
   private val log = LoggerFactory.getLogger(ExoDownloadTask::class.java)
@@ -41,7 +45,7 @@ class ExoDownloadTask(
   private val stateLock: Any = Object()
   @GuardedBy("stateLock")
   private var state: State =
-    when (this.spineElement.partFile.isFile) {
+    when (this.partFile.isFile) {
       true -> Downloaded
       false -> Initial
     }
@@ -72,35 +76,27 @@ class ExoDownloadTask(
 
   private fun onNotDownloaded() {
     this.log.debug("not downloaded")
-    this.spineElement.setDownloadStatus(PlayerSpineElementNotDownloaded(this.spineElement))
+    this.spineElements.forEach { spineElement ->
+      spineElement.setDownloadStatus(PlayerSpineElementNotDownloaded(spineElement))
+    }
   }
 
   private fun onDownloading(percent: Int) {
     this.percent = percent
-    this.spineElement.setDownloadStatus(PlayerSpineElementDownloading(this.spineElement, percent))
+    this.spineElements.forEach { spineElement ->
+      spineElement.setDownloadStatus(PlayerSpineElementDownloading(spineElement, percent))
+    }
   }
 
   private fun onDownloaded() {
     this.log.debug("downloaded")
-    this.spineElement.setDownloadStatus(PlayerSpineElementDownloaded(this.spineElement))
+    this.spineElements.forEach { spineElement ->
+      spineElement.setDownloadStatus(PlayerSpineElementDownloaded(spineElement))
+    }
   }
 
-  private fun onStartDownload(
-    targetLink: PlayerManifestLink
-  ): ListenableFuture<Unit> {
-    this.log.debug("download: {}", targetLink.hrefURI)
-
-    val request =
-      PlayerDownloadRequest(
-        uri = targetLink.hrefURI ?: URI.create("urn:missing"),
-        credentials = null,
-        outputFile = this.spineElement.partFile,
-        userAgent = this.userAgent,
-        onProgress = { percent -> this.onDownloading(percent) }
-      )
-
-    val future =
-      this.onStartDownloadForRequest(request, targetLink)
+  private fun createDownloadingRequest(future: ListenableFuture<Unit>,
+                                       targetLink: PlayerManifestLink) {
 
     this.stateSetCurrent(Downloading(future))
     this.onBroadcastState()
@@ -132,6 +128,24 @@ class ExoDownloadTask(
       },
       this.downloadStatusExecutor
     )
+  }
+
+  private fun onStartDownload(): ListenableFuture<Unit> {
+    this.log.debug("download: {}", this.originalLink.hrefURI)
+
+    val request =
+      PlayerDownloadRequest(
+        uri = this.originalLink.hrefURI ?: URI.create("urn:missing"),
+        credentials = null,
+        outputFile = this.partFile,
+        userAgent = this.userAgent,
+        onProgress = { percent -> this.onDownloading(percent) }
+      )
+
+    val future =
+      this.onStartDownloadForRequest(request, this.originalLink)
+
+    this.createDownloadingRequest(future, this.originalLink)
 
     return future
   }
@@ -166,21 +180,25 @@ class ExoDownloadTask(
   private fun onDownloadExpired(exception: Exception) {
     this.log.error("onDownloadExpired: ", exception)
     this.stateSetCurrent(Initial)
-    this.spineElement.setDownloadStatus(
-      PlayerSpineElementDownloadExpired(
-        this.spineElement, exception, exception.message ?: "Missing exception message"
+    this.spineElements.forEach { spineElement ->
+      spineElement.setDownloadStatus(
+        PlayerSpineElementDownloadExpired(
+          spineElement, exception, exception.message ?: "Missing exception message"
+        )
       )
-    )
+    }
   }
 
   private fun onDownloadFailed(exception: Exception) {
     this.log.error("onDownloadFailed: ", exception)
     this.stateSetCurrent(Initial)
-    this.spineElement.setDownloadStatus(
-      PlayerSpineElementDownloadFailed(
-        this.spineElement, exception, exception.message ?: "Missing exception message"
+    this.spineElements.forEach { spineElement ->
+      spineElement.setDownloadStatus(
+        PlayerSpineElementDownloadFailed(
+          spineElement, exception, exception.message ?: "Missing exception message"
+        )
       )
-    )
+    }
   }
 
   private fun onDownloadCompleted() {
@@ -198,10 +216,10 @@ class ExoDownloadTask(
   }
 
   private fun onDeleteDownloaded() {
-    this.log.debug("deleting file {}", this.spineElement.partFile)
+    this.log.debug("deleting file {}", this.partFile)
 
     try {
-      ExoFileIO.fileDelete(this.spineElement.partFile)
+      ExoFileIO.fileDelete(this.partFile)
     } catch (e: Exception) {
       this.log.error("failed to delete file: ", e)
     } finally {
@@ -220,13 +238,23 @@ class ExoDownloadTask(
     }
   }
 
+  fun isSpineElementFromList(spineElement: ExoSpineElement): Boolean {
+    return spineElements.contains(spineElement)
+  }
+
   override fun fetch() {
     this.log.debug("fetch")
 
     when (this.stateGetCurrent()) {
-      Initial -> this.onStartDownload(this.spineElement.itemManifest.originalLink)
-      Downloaded -> this.onDownloaded()
-      is Downloading -> this.onDownloading(this.percent)
+      Initial -> {
+        this.onStartDownload()
+      }
+      Downloaded -> {
+        this.onDownloaded()
+      }
+      is Downloading -> {
+        this.onDownloading(this.percent)
+      }
     }
   }
 
@@ -243,4 +271,7 @@ class ExoDownloadTask(
 
   override val progress: Double
     get() = this.percent.toDouble()
+
+  override val spineItems: List<PlayerSpineElementType>
+    get() = this.spineElements
 }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.audiobook.open_access
 
 import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
+import org.librarysimplified.audiobook.api.PlayerSpineElementType
 
 /**
  * An Exo implementation of the download-whole-book task.
@@ -11,21 +12,30 @@ class ExoDownloadWholeBookTask(
 ) : PlayerDownloadWholeBookTaskType {
 
   override fun fetch() {
-    this.audioBook.spine.map { item -> item.downloadTask().fetch() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.fetch()
+    }
   }
 
   override fun cancel() {
-    this.audioBook.spine.map { item -> item.downloadTask().cancel() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.cancel()
+    }
   }
 
   override fun delete() {
-    this.audioBook.spine.map { item -> item.downloadTask().delete() }
+    this.audioBook.downloadTasks.forEach { task ->
+      task.delete()
+    }
   }
 
   override val progress: Double
     get() = calculateProgress()
 
+  override val spineItems: List<PlayerSpineElementType>
+    get() = audioBook.spine
+
   private fun calculateProgress(): Double {
-    return this.audioBook.spine.sumByDouble { item -> item.downloadTask().progress } / this.audioBook.spine.size
+    return this.audioBook.downloadTasks.sumOf { task -> task.progress } / this.audioBook.downloadTasks.size
   }
 }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
@@ -29,6 +29,10 @@ class ExoDownloadWholeBookTask(
     }
   }
 
+  override fun fulfillsSpineElement(spineElement: PlayerSpineElementType): Boolean {
+    return spineItems.contains(spineElement)
+  }
+
   override val progress: Double
     get() = calculateProgress()
 

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
@@ -4,17 +4,11 @@ import net.jcip.annotations.GuardedBy
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
-import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementNotDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
-import org.librarysimplified.audiobook.api.PlayerUserAgent
-import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
 import rx.subjects.PublishSubject
-import java.io.File
-import java.util.concurrent.ExecutorService
 
 /**
  * A spine element in an audio book.
@@ -24,15 +18,10 @@ class ExoSpineElement(
   private val downloadStatusEvents: PublishSubject<PlayerSpineElementDownloadStatus>,
   private val bookID: PlayerBookID,
   val itemManifest: ExoManifestSpineItem,
-  internal val partFile: File,
-  private val extensions: List<PlayerExtensionType>,
-  private val downloadProvider: PlayerDownloadProviderType,
   override val index: Int,
   internal var nextElement: PlayerSpineElementType?,
   internal var previousElement: PlayerSpineElementType?,
-  @Volatile override var duration: Duration?,
-  private val engineExecutor: ExecutorService,
-  private val userAgent: PlayerUserAgent
+  @Volatile override var duration: Duration?
 ) : PlayerSpineElementType {
 
   /**
@@ -69,19 +58,6 @@ class ExoSpineElement(
 
   override val title: String?
     get() = this.itemManifest.title
-
-  private val downloadTask: PlayerDownloadTaskType =
-    ExoDownloadTask(
-      downloadStatusExecutor = this.engineExecutor,
-      downloadProvider = this.downloadProvider,
-      spineElement = this,
-      extensions = this.extensions,
-      userAgent = this.userAgent
-    )
-
-  override fun downloadTask(): PlayerDownloadTaskType {
-    return this.downloadTask
-  }
 
   fun setBook(book: ExoAudioBook) {
     this.bookActual = book

--- a/org.librarysimplified.audiobook.rbdigital/src/main/java/org/librarysimplified/audiobook/rbdigital/RBDigitialPlayerExtension.kt
+++ b/org.librarysimplified.audiobook.rbdigital/src/main/java/org/librarysimplified/audiobook/rbdigital/RBDigitialPlayerExtension.kt
@@ -35,7 +35,7 @@ class RBDigitialPlayerExtension : PlayerExtensionType {
         link = link
       )
     } else {
-      return null
+      null
     }
   }
 

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -73,14 +73,19 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     this.book.supportsStreaming = false
 
     for (i in 1..100) {
+
       val e = this.book.createSpineElement(
         "id$i",
         this.lorem.lines[i % this.lorem.lines.size],
         Duration.standardSeconds(20)
       )
 
+      val downloadTask = this.book.createDownloadTask(
+        listOf(e)
+      )
+
       if (!i.toString().endsWith("3")) {
-        e.downloadTask().fetch()
+        downloadTask.fetch()
       }
     }
 

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ExoUriDownloadProvider.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ExoUriDownloadProvider.kt
@@ -1,0 +1,39 @@
+package org.librarysimplified.audiobook.tests
+
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.ListenableFutureTask
+import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerDownloadRequest
+import java.net.URI
+
+/**
+ * An implementation of the {@link PlayerDownloadProviderType} interface that receives a map with
+ * the URIs that will be downloaded and the number of times they were downloaded.
+ */
+
+class ExoUriDownloadProvider(private val downloadTimes: HashMap<URI, Int>) :
+  PlayerDownloadProviderType {
+
+  override fun download(request: PlayerDownloadRequest): ListenableFuture<Unit> {
+
+    val numberOfTimesUriWasDownloaded = downloadTimes[request.uri]
+
+    // check if this URI is in the map and if it's not add it with
+    if (numberOfTimesUriWasDownloaded == null) {
+      downloadTimes[request.uri] = 0
+
+      // the URI is on the list, so we increment the number of times it was downloaded
+    } else {
+      downloadTimes[request.uri] = numberOfTimesUriWasDownloaded + 1
+    }
+
+    return ListenableFutureTask.create(
+      {
+        request.onProgress.invoke(0)
+        request.onProgress.invoke(50)
+        request.onProgress.invoke(100)
+      },
+      Unit
+    )
+  }
+}

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/lcp/LCPEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/lcp/LCPEngineProviderContract.kt
@@ -93,6 +93,24 @@ abstract class LCPEngineProviderContract {
   }
 
   /**
+   * Test that the engine rejects the Summer Wives (Feedbooks) book.
+   */
+
+  @Test
+  fun feedbooksManifest_isRejected() {
+    val manifest = this.parseManifest("summerwives.audiobook-manifest.json")
+    val request = PlayerAudioEngineRequest(
+      manifest = manifest,
+      filter = { true },
+      downloadProvider = DishonestDownloadProvider(),
+      userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+    )
+    val engine_provider = LCPEngineProvider()
+    val book_provider = engine_provider.tryRequest(request)
+    Assertions.assertNull(book_provider, "Engine must reject Feedbooks manifest")
+  }
+
+  /**
    * Test that the player does not support streaming.
    */
 

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/lcp/LCPEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/lcp/LCPEngineProviderContract.kt
@@ -7,7 +7,6 @@ import org.librarysimplified.audiobook.api.*
 import org.librarysimplified.audiobook.lcp.LCPEngineProvider
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
 import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
-import org.librarysimplified.audiobook.open_access.ExoEngineProvider
 import org.librarysimplified.audiobook.parser.api.ParseResult
 import org.librarysimplified.audiobook.tests.DishonestDownloadProvider
 import org.mockito.Mockito
@@ -91,24 +90,6 @@ abstract class LCPEngineProviderContract {
     val engine_provider = LCPEngineProvider()
     val book_provider = engine_provider.tryRequest(request)
     Assertions.assertNull(book_provider, "Engine must reject open access manifest")
-  }
-
-  /**
-   * Test that the engine rejects the Summer Wives (Feedbooks) book.
-   */
-
-  @Test
-  fun feedbooksManifest_isRejected() {
-    val manifest = this.parseManifest("summerwives.audiobook-manifest.json")
-    val request = PlayerAudioEngineRequest(
-      manifest = manifest,
-      filter = { true },
-      downloadProvider = DishonestDownloadProvider(),
-      userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
-    )
-    val engine_provider = LCPEngineProvider()
-    val book_provider = engine_provider.tryRequest(request)
-    Assertions.assertNull(book_provider, "Engine must reject Feedbooks manifest")
   }
 
   /**

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoDownloadContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoDownloadContract.kt
@@ -1,0 +1,88 @@
+package org.librarysimplified.audiobook.tests.open_access
+
+import android.content.Context
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
+import org.librarysimplified.audiobook.api.PlayerAudioEngines
+import org.librarysimplified.audiobook.api.PlayerResult
+import org.librarysimplified.audiobook.api.PlayerUserAgent
+import org.librarysimplified.audiobook.manifest.api.PlayerManifest
+import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
+import org.librarysimplified.audiobook.parser.api.ParseResult
+import org.librarysimplified.audiobook.tests.ExoUriDownloadProvider
+import org.slf4j.Logger
+import java.net.URI
+
+abstract class ExoDownloadContract {
+
+  abstract fun log(): Logger
+
+  abstract fun context(): Context
+
+  @Test
+  fun testDownloadFlatlandURIsJustOnce() {
+
+    val result =
+      ManifestParsers.parse(
+        uri = URI.create("urn:flatland"),
+        streams = resource("flatland_toc.audiobook-manifest.json"),
+        extensions = listOf()
+      )
+
+    this.log().debug("result: {}", result)
+    Assertions.assertTrue(result is ParseResult.Success, "Result is success")
+
+    val success: ParseResult.Success<PlayerManifest> =
+      result as ParseResult.Success<PlayerManifest>
+
+    val manifest = success.result
+
+    // create a hashmap with the list of URIs to download and the number of times they were downloaded
+    val urisDownloadMap = hashMapOf<URI, Int>()
+    manifest.readingOrder.forEach {
+      if (it.hrefURI != null) {
+        urisDownloadMap[it.hrefURI!!] = 0
+      }
+    }
+
+    val engine =
+      PlayerAudioEngines.findBestFor(
+        PlayerAudioEngineRequest(
+          manifest = manifest,
+          filter = { true },
+          downloadProvider = ExoUriDownloadProvider(urisDownloadMap),
+          userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+        )
+      )
+
+    Assertions.assertNotNull(engine)
+
+    val bookResult =
+      engine?.bookProvider?.create(
+        context = context(),
+        extensions = listOf()
+      )
+
+    Assertions.assertNotNull(engine)
+
+    val audiobook = (bookResult as PlayerResult.Success).result
+
+    // start downloading the book
+    audiobook.wholeBookDownloadTask.fetch()
+
+    // confirm that there are no new URIs added to the hashMap
+    Assertions.assertTrue(urisDownloadMap.size == manifest.readingOrder.size)
+
+    // confirm that all the URIs were downloaded just once
+    urisDownloadMap.keys.forEach {
+      Assertions.assertTrue(urisDownloadMap[it] == 1)
+    }
+  }
+
+  private fun resource(name: String): ByteArray {
+    val path = "/org/librarysimplified/audiobook/tests/" + name
+    return ExoManifestContract::class.java.getResourceAsStream(path)?.readBytes()
+      ?: throw AssertionError("Missing resource file: " + path)
+  }
+}

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import org.librarysimplified.audiobook.api.PlayerAudioBookType
-import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
-import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerEvent
+import org.librarysimplified.audiobook.api.*
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterCompleted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterWaiting
@@ -24,19 +21,16 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
-import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadFailed
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloading
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementNotDownloaded
-import org.librarysimplified.audiobook.api.PlayerSpineElementType
-import org.librarysimplified.audiobook.api.PlayerType
-import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
 import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
 import org.librarysimplified.audiobook.manifest.api.PlayerManifestMetadata
 import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
+import org.librarysimplified.audiobook.open_access.ExoDownloadTask
 import org.librarysimplified.audiobook.open_access.ExoEngineProvider
 import org.librarysimplified.audiobook.open_access.ExoEngineThread
 import org.librarysimplified.audiobook.open_access.ExoSpineElement
@@ -275,11 +269,11 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
+    book.downloadTasks.first().delete()
     Thread.sleep(1000L)
 
     player.play()
-    this.downloadSpineItemAndWait(book.spine[0])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
     Thread.sleep(1000L)
 
     player.close()
@@ -336,10 +330,10 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
+    book.downloadTasks.first().delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
     Thread.sleep(1000L)
 
     player.play()
@@ -383,10 +377,11 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks.first().delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
     Thread.sleep(1000L)
 
     player.play()
@@ -442,12 +437,12 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
-    book.spine[1].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks[1].delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
-    this.downloadSpineItemAndWait(book.spine[1])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
+    this.downloadSpineItemAndWait(book.downloadTasks[1])
     Thread.sleep(1000L)
 
     player.play()
@@ -506,15 +501,15 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
+    book.downloadTasks.first().delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
     Thread.sleep(1000L)
 
     player.play()
     Thread.sleep(1000L)
-    book.spine[0].downloadTask().delete()
+    book.downloadTasks.first().delete()
     Thread.sleep(2000L)
 
     player.close()
@@ -559,12 +554,12 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
-    book.spine[1].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks[1].delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
-    this.downloadSpineItemAndWait(book.spine[1])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
+    this.downloadSpineItemAndWait(book.downloadTasks[1])
 
     player.play()
     player.skipToNextChapter()
@@ -624,12 +619,12 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
-    book.spine[1].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks[1].delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
-    this.downloadSpineItemAndWait(book.spine[1])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
+    this.downloadSpineItemAndWait(book.downloadTasks[1])
     Thread.sleep(1000L)
 
     player.playAtLocation(book.spine[1].position)
@@ -697,12 +692,12 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
-    book.spine[1].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks[1].delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
-    this.downloadSpineItemAndWait(book.spine[1])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
+    this.downloadSpineItemAndWait(book.downloadTasks[1])
     Thread.sleep(1000L)
 
     player.playAtLocation(book.spine[1].position)
@@ -757,12 +752,12 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.spine[0].downloadTask().delete()
-    book.spine[1].downloadTask().delete()
+    book.downloadTasks.first().delete()
+    book.downloadTasks[1].delete()
     Thread.sleep(1000L)
 
-    this.downloadSpineItemAndWait(book.spine[0])
-    this.downloadSpineItemAndWait(book.spine[1])
+    this.downloadSpineItemAndWait(book.downloadTasks.first())
+    this.downloadSpineItemAndWait(book.downloadTasks[1])
     Thread.sleep(1000L)
 
     player.playAtBookStart()
@@ -790,13 +785,13 @@ abstract class ExoEngineProviderContract {
     }
   }
 
-  private fun downloadSpineItemAndWait(spineItem: PlayerSpineElementType) {
-    spineItem.downloadTask().delete()
-    spineItem.downloadTask().fetch()
+  private fun downloadSpineItemAndWait(downloadTask: PlayerDownloadTaskType) {
+    downloadTask.delete()
+    downloadTask.fetch()
 
     var downloaded = false
     while (!downloaded) {
-      val status = spineItem.downloadStatus
+      val status = downloadTask.spineItems.first().downloadStatus
       this.log().debug("spine element status: {}", status)
 
       when (status) {
@@ -1058,8 +1053,8 @@ abstract class ExoEngineProviderContract {
     val audioBook =
       (result as PlayerResult.Success).result
 
-    audioBook.spine[0].downloadTask().fetch()
-    audioBook.spine[1].downloadTask().fetch()
+    audioBook.downloadTasks.first().fetch()
+    audioBook.downloadTasks[1].fetch()
 
     Thread.sleep(1_000L)
 

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
@@ -11,7 +11,11 @@ import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import org.librarysimplified.audiobook.api.*
+import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
+import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
+import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventPlaybackRateChanged
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterCompleted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventChapterWaiting
@@ -21,16 +25,18 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadFailed
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloading
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementNotDownloaded
+import org.librarysimplified.audiobook.api.PlayerType
+import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
 import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
 import org.librarysimplified.audiobook.manifest.api.PlayerManifestMetadata
 import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
-import org.librarysimplified.audiobook.open_access.ExoDownloadTask
 import org.librarysimplified.audiobook.open_access.ExoEngineProvider
 import org.librarysimplified.audiobook.open_access.ExoEngineThread
 import org.librarysimplified.audiobook.open_access.ExoSpineElement
@@ -377,7 +383,6 @@ abstract class ExoEngineProviderContract {
     val events = ArrayList<String>()
     this.subscribeToEvents(player, events, waitLatch)
 
-    book.downloadTasks.first().delete()
     book.downloadTasks.first().delete()
     Thread.sleep(1000L)
 

--- a/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/ExoDownloadTest.kt
+++ b/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/ExoDownloadTest.kt
@@ -1,0 +1,17 @@
+package org.librarysimplified.audiobook.tests.local
+
+import android.content.Context
+import org.librarysimplified.audiobook.tests.open_access.ExoDownloadContract
+import org.mockito.Mockito
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ExoDownloadTest : ExoDownloadContract() {
+  override fun log(): Logger {
+    return LoggerFactory.getLogger(ExoDownloadTest::class.java)
+  }
+
+  override fun context(): Context {
+    return Mockito.mock(Context::class.java)
+  }
+}

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -139,7 +139,7 @@ class PlayerFragment : Fragment() {
     super.onCreate(state)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
+      requireArguments().getSerializable(parametersKey)
         as PlayerFragmentParameters
     this.timeStrings =
       PlayerTimeStrings.SpokenTranslations.createFromResources(this.resources)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -107,7 +107,7 @@ class PlayerTOCAdapter(
           if (item.downloadTasksSupported) {
             holder.notDownloadedStreamableRefresh.setOnClickListener {
               downloadTasks.firstOrNull { task ->
-                task.spineItems.contains(item)
+                task.fulfillsSpineElement(item)
               }?.fetch()
             }
             holder.notDownloadedStreamableRefresh.contentDescription =
@@ -127,7 +127,7 @@ class PlayerTOCAdapter(
           if (item.downloadTasksSupported) {
             holder.notDownloadedStreamableRefresh.setOnClickListener {
               downloadTasks.firstOrNull { task ->
-                task.spineItems.contains(item)
+                task.fulfillsSpineElement(item)
               }?.fetch()
             }
             holder.notDownloadedStreamableRefresh.contentDescription =
@@ -193,7 +193,7 @@ class PlayerTOCAdapter(
         if (item.downloadTasksSupported) {
           holder.downloadFailedRefresh.setOnClickListener {
             val task = downloadTasks.firstOrNull { task ->
-              task.spineItems.contains(item)
+              task.fulfillsSpineElement(item)
             }
             task?.cancel()
             task?.fetch()
@@ -288,7 +288,7 @@ class PlayerTOCAdapter(
           R.string.audiobook_part_download_stop,
           { _: DialogInterface, _: Int ->
             downloadTasks.firstOrNull { task ->
-              task.spineItems.contains(item)
+              task.fulfillsSpineElement(item)
             }?.cancel()
           }
         )

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormatter
 import org.joda.time.format.PeriodFormatterBuilder
+import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadFailed
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloaded
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloading
@@ -28,6 +29,7 @@ import org.librarysimplified.audiobook.api.PlayerSpineElementType
 class PlayerTOCAdapter(
   private val context: Context,
   private val spineElements: List<PlayerSpineElementType>,
+  private val downloadTasks: List<PlayerDownloadTaskType>,
   private val onSelect: (PlayerSpineElementType) -> Unit,
 ) :
   RecyclerView.Adapter<PlayerTOCAdapter.ViewHolder>() {
@@ -103,7 +105,11 @@ class PlayerTOCAdapter(
           holder.buttonsNotDownloadedStreamable.visibility = VISIBLE
 
           if (item.downloadTasksSupported) {
-            holder.notDownloadedStreamableRefresh.setOnClickListener { item.downloadTask().fetch() }
+            holder.notDownloadedStreamableRefresh.setOnClickListener {
+              downloadTasks.firstOrNull { task ->
+                task.spineItems.contains(item)
+              }?.fetch()
+            }
             holder.notDownloadedStreamableRefresh.contentDescription =
               this.context.getString(
                 R.string.audiobook_accessibility_toc_download,
@@ -119,7 +125,11 @@ class PlayerTOCAdapter(
           holder.buttonsNotDownloadedStreamable.visibility = INVISIBLE
 
           if (item.downloadTasksSupported) {
-            holder.notDownloadedStreamableRefresh.setOnClickListener { item.downloadTask().fetch() }
+            holder.notDownloadedStreamableRefresh.setOnClickListener {
+              downloadTasks.firstOrNull { task ->
+                task.spineItems.contains(item)
+              }?.fetch()
+            }
             holder.notDownloadedStreamableRefresh.contentDescription =
               this.context.getString(
                 R.string.audiobook_accessibility_toc_download,
@@ -168,7 +178,9 @@ class PlayerTOCAdapter(
         holder.view.isEnabled = true
 
         holder.downloadedDurationText.text =
-          item.duration?.let { this.periodFormatter.print(it.toPeriod()) } ?: ""
+          item.duration?.let {
+            this.periodFormatter.print(it.toPeriod())
+          } ?: ""
       }
 
       is PlayerSpineElementDownloadFailed -> {
@@ -180,8 +192,11 @@ class PlayerTOCAdapter(
 
         if (item.downloadTasksSupported) {
           holder.downloadFailedRefresh.setOnClickListener {
-            item.downloadTask().cancel()
-            item.downloadTask().fetch()
+            val task = downloadTasks.firstOrNull { task ->
+              task.spineItems.contains(item)
+            }
+            task?.cancel()
+            task?.fetch()
           }
           holder.downloadFailedRefresh.contentDescription =
             this.context.getString(R.string.audiobook_accessibility_toc_retry, normalIndex)
@@ -271,7 +286,11 @@ class PlayerTOCAdapter(
         .setMessage(R.string.audiobook_part_download_stop_confirm)
         .setPositiveButton(
           R.string.audiobook_part_download_stop,
-          { _: DialogInterface, _: Int -> item.downloadTask().cancel() }
+          { _: DialogInterface, _: Int ->
+            downloadTasks.firstOrNull { task ->
+              task.spineItems.contains(item)
+            }?.cancel()
+          }
         )
         .setNegativeButton(
           R.string.audiobook_part_download_continue,

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
@@ -103,8 +103,8 @@ class PlayerTOCFragment : Fragment() {
     super.onAttach(context)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
-      as PlayerTOCFragmentParameters
+      this.requireArguments().getSerializable(parametersKey)
+        as PlayerTOCFragmentParameters
 
     if (context is PlayerFragmentListenerType) {
       this.listener = context
@@ -116,6 +116,7 @@ class PlayerTOCFragment : Fragment() {
         PlayerTOCAdapter(
           context = context,
           spineElements = this.book.spine,
+          downloadTasks = this.book.downloadTasks,
           onSelect = { item -> this.onTOCItemSelected(item) }
         )
 
@@ -174,7 +175,7 @@ class PlayerTOCFragment : Fragment() {
       if (refreshVisibleNow != refreshVisibleThen || cancelVisibleNow != cancelVisibleThen) {
         this.menuRefreshAll.isVisible = refreshVisibleNow
         this.menuCancelAll.isVisible = cancelVisibleNow
-        this.activity!!.invalidateOptionsMenu()
+        this.requireActivity().invalidateOptionsMenu()
       }
     }
   }
@@ -252,7 +253,7 @@ class PlayerTOCFragment : Fragment() {
     try {
       this.listener.onPlayerAccessibilityEvent(
         PlayerAccessibilityChapterSelected(
-          this.context!!.getString(R.string.audiobook_accessibility_toc_selected, item.index + 1)
+          this.getString(R.string.audiobook_accessibility_toc_selected, item.index + 1)
         )
       )
     } catch (ex: Exception) {


### PR DESCRIPTION
**What's this do?**
This PR updates the audiobook chapter/tracks downloading logic. Instead of having a download task associated to a spine item, now we have a list of spine items associated to a download task, so when it starts fetching, all of its associated spine items have their downloading status updated at the same time with the same value.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Update-audiobook-chapter-download-logic-acd3305e0ef147bd8478200cac96117a) to do this because in some audiobooks, some chapters have the same file with a different offset, so in this case the same file was being downloaded more than once, which could result in large waiting times for the user.

**How should this be tested? / Do these changes have associated tests?**
Open the sample player
Choose the "Flatland TOC" book
Open the TOC screen
Verify that there are [some chapters being downloaded at the same time with the same status](https://user-images.githubusercontent.com/79104027/166295983-79c358b3-0e66-4676-b12b-53a3e8734a31.png)
Click on the loading animation of the first item and click on "Stop"
Verify [the first 4 tracks have stopped being downloaded](https://user-images.githubusercontent.com/79104027/166296041-ed1ec9e4-b2b6-40fe-9567-18048d0fa2ee.png)


**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 