### PR TITLE
Add support for bearer token negotiation when downloading manifests.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,9 +175,10 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-02T16:57:34+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-05-17T05:03:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
-        <c:change date="2022-05-02T16:57:34+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
+        <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
+        <c:change date="2022-05-17T05:03:47+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 ext {
   androidBuildToolsVersion = "30.0.2"
-  androidCompileSDKVersion = 28
+  androidCompileSDKVersion = 31
   androidMinimumSDKVersion = 21
   androidTargetSDKVersion = 28
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-audiobook.g
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-audiobook.git
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
-VERSION_NAME=7.0.2-SNAPSHOT
-VERSION_PREVIOUS=6.11.0
+VERSION_NAME=8.0.0-SNAPSHOT
+VERSION_PREVIOUS=7.0.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.demo/build.gradle
+++ b/org.librarysimplified.audiobook.demo/build.gradle
@@ -33,6 +33,8 @@ dependencies {
   implementation libs.androidx.recycler.view
   implementation libs.kotlin.stdlib
   implementation libs.okhttp3
+  implementation libs.palace.http.api
+  implementation libs.palace.http.vanilla
   implementation libs.slf4j
   implementation libs.logback.android
   implementation libs.nypl.theme

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -60,6 +60,8 @@ import org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment
 import org.librarysimplified.audiobook.views.PlayerSleepTimerFragment
 import org.librarysimplified.audiobook.views.PlayerTOCFragment
 import org.librarysimplified.audiobook.views.PlayerTOCFragmentParameters
+import org.librarysimplified.http.api.LSHTTPClientConfiguration
+import org.librarysimplified.http.vanilla.LSHTTPClients
 import org.slf4j.LoggerFactory
 import rx.Subscription
 import java.io.File
@@ -83,6 +85,14 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
   }
 
   private val userAgent = PlayerUserAgent("org.librarysimplified.audiobook.demo.main_ui")
+
+  private val httpClient = LSHTTPClients().create(
+    context = this,
+    configuration = LSHTTPClientConfiguration(
+      applicationName = "org.librarysimplified.audiobook.demo.ExamplePlayerActivity",
+      applicationVersion = "1.0.0"
+    )
+  )
 
   private lateinit var bookmarks: ExampleBookmarkDatabase
   private lateinit var examplePlayerFetchingFragment: ExamplePlayerFetchingFragment
@@ -280,6 +290,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
           ManifestFulfillmentBasicParameters(
             uri = URI.create(parameters.fetchURI),
             credentials = null,
+            httpClient = this.httpClient,
             userAgent = this.userAgent
           )
         )
@@ -300,6 +311,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
           ManifestFulfillmentBasicParameters(
             uri = URI.create(parameters.fetchURI),
             credentials = credentials,
+            httpClient = this.httpClient,
             userAgent = this.userAgent
           )
         )
@@ -320,6 +332,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
           ManifestFulfillmentBasicParameters(
             uri = URI.create(parameters.fetchURI),
             credentials = credentials,
+            httpClient = this.httpClient,
             userAgent = this.userAgent
           )
         )
@@ -420,7 +433,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
       throw exception
     }
 
-    val (_, downloadBytes) = (downloadResult as PlayerResult.Success).result
+    val (_, _, downloadBytes) = (downloadResult as PlayerResult.Success).result
     cacheManifest(downloadBytes)
 
     val parseResult =

--- a/org.librarysimplified.audiobook.manifest_fulfill.basic/build.gradle
+++ b/org.librarysimplified.audiobook.manifest_fulfill.basic/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect
   implementation libs.okhttp3
+  implementation libs.palace.http.api
   implementation libs.slf4j
 
   compileOnly libs.jcip

--- a/org.librarysimplified.audiobook.manifest_fulfill.basic/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/basic/ManifestFulfillmentBasicParameters.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.basic/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/basic/ManifestFulfillmentBasicParameters.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.audiobook.manifest_fulfill.basic
 
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentStrategyParametersType
+import org.librarysimplified.http.api.LSHTTPClientType
 import java.net.URI
 
 /**
@@ -11,5 +12,6 @@ import java.net.URI
 data class ManifestFulfillmentBasicParameters(
   val uri: URI,
   val credentials: ManifestFulfillmentBasicCredentials?,
+  val httpClient: LSHTTPClientType,
   override val userAgent: PlayerUserAgent
 ) : ManifestFulfillmentStrategyParametersType

--- a/org.librarysimplified.audiobook.manifest_fulfill.spi/build.gradle
+++ b/org.librarysimplified.audiobook.manifest_fulfill.spi/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect
+  implementation libs.palace.http.api
 
   compileOnly libs.jcip
 }

--- a/org.librarysimplified.audiobook.manifest_fulfill.spi/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/spi/ManifestFulfilled.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.spi/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/spi/ManifestFulfilled.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.audiobook.manifest_fulfill.spi
 
 import one.irradia.mime.api.MIMEType
+import org.librarysimplified.http.api.LSHTTPAuthorizationType
 
 /**
  * A downloaded manifest.
@@ -8,5 +9,6 @@ import one.irradia.mime.api.MIMEType
 
 data class ManifestFulfilled(
   val contentType: MIMEType,
+  val authorization: LSHTTPAuthorizationType? = null,
   val data: ByteArray
 )

--- a/org.librarysimplified.audiobook.open_access/build.gradle
+++ b/org.librarysimplified.audiobook.open_access/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation libs.joda.time
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect
+  implementation libs.palace.http.api
   implementation libs.slf4j
 
   compileOnly libs.jcip

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/BearerTokenExtension.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/BearerTokenExtension.kt
@@ -1,0 +1,59 @@
+package org.librarysimplified.audiobook.open_access
+
+import com.google.common.util.concurrent.ListenableFuture
+import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerDownloadRequest
+import org.librarysimplified.audiobook.api.PlayerDownloadRequestCredentials
+import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
+import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
+import org.librarysimplified.http.api.LSHTTPAuthorizationType
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ExecutorService
+
+class BearerTokenExtension : PlayerExtensionType {
+  private val logger =
+    LoggerFactory.getLogger(BearerTokenExtension::class.java)
+
+  override val name: String =
+    "org.librarysimplified.audiobook.open_access.BearerTokenExtension"
+
+  @Volatile
+  var authorization: LSHTTPAuthorizationType? = null
+
+  override fun onDownloadLink(
+    statusExecutor: ExecutorService,
+    downloadProvider: PlayerDownloadProviderType,
+    originalRequest: PlayerDownloadRequest,
+    link: PlayerManifestLink
+  ): ListenableFuture<Unit>? {
+    val authHeader = authorization?.toHeaderValue()
+
+    return if (
+      link.properties.encrypted?.scheme == null &&
+      originalRequest.credentials == null &&
+      authHeader != null &&
+      authHeader.lowercase().startsWith("bearer ")
+    ) {
+      this.downloadWithBearerToken(
+        downloadProvider = downloadProvider,
+        originalRequest = originalRequest,
+        token = authHeader.substring("bearer ".length)
+      )
+    } else {
+      null
+    }
+  }
+
+  private fun downloadWithBearerToken(
+    downloadProvider: PlayerDownloadProviderType,
+    originalRequest: PlayerDownloadRequest,
+    token: String
+  ): ListenableFuture<Unit> {
+    this.logger.debug("running bearer token authentication for {}", originalRequest.uri)
+
+    val newRequest =
+      originalRequest.copy(credentials = PlayerDownloadRequestCredentials.BearerToken(token))
+
+    return downloadProvider.download(newRequest)
+  }
+}

--- a/org.librarysimplified.audiobook.open_access/src/main/resources/META-INF/services/org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
+++ b/org.librarysimplified.audiobook.open_access/src/main/resources/META-INF/services/org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
@@ -1,0 +1,1 @@
+org.librarysimplified.audiobook.open_access.BearerTokenExtension

--- a/org.librarysimplified.audiobook.tests/build.gradle
+++ b/org.librarysimplified.audiobook.tests/build.gradle
@@ -24,6 +24,8 @@ dependencies {
   implementation libs.junit.jupiter.api
   implementation libs.junit.jupiter.engine
   implementation libs.mockito.kotlin
+  implementation libs.palace.http.api
+  implementation libs.palace.http.vanilla
   implementation libs.r2.streamer
 
   testImplementation libs.logback.classic

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/BearerTokenExtensionContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/BearerTokenExtensionContract.kt
@@ -1,0 +1,255 @@
+package org.librarysimplified.audiobook.tests.open_access
+
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.ListeningExecutorService
+import com.google.common.util.concurrent.MoreExecutors
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerDownloadRequest
+import org.librarysimplified.audiobook.api.PlayerDownloadRequestCredentials
+import org.librarysimplified.audiobook.api.PlayerUserAgent
+import org.librarysimplified.audiobook.manifest.api.PlayerManifestEncrypted
+import org.librarysimplified.audiobook.manifest.api.PlayerManifestLink
+import org.librarysimplified.audiobook.manifest.api.PlayerManifestLinkProperties
+import org.librarysimplified.audiobook.open_access.BearerTokenExtension
+import org.librarysimplified.audiobook.tests.TestDirectories
+import org.librarysimplified.http.api.LSHTTPAuthorizationBasic
+import org.librarysimplified.http.api.LSHTTPAuthorizationBearerToken
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.net.URI
+import java.util.LinkedList
+import java.util.UUID
+import java.util.concurrent.Executors
+
+abstract class BearerTokenExtensionContract {
+  private val logger = LoggerFactory.getLogger(BearerTokenExtensionContract::class.java)
+  private lateinit var downloadProvider: FakeDownloadProvider
+  private lateinit var executor: ListeningExecutorService
+
+  @BeforeEach
+  fun testSetup() {
+    this.executor =
+      MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
+    this.downloadProvider =
+      FakeDownloadProvider()
+  }
+
+  class FakeDownloadProvider : PlayerDownloadProviderType {
+    val requests =
+      LinkedList<PlayerDownloadRequest>()
+
+    override fun download(
+      request: PlayerDownloadRequest
+    ): ListenableFuture<Unit> {
+      this.requests.add(request)
+      return Futures.immediateFuture(Unit)
+    }
+  }
+
+  @AfterEach
+  fun testTearDown() {
+    this.executor.shutdown()
+  }
+
+  /**
+   * The extension doesn't handle a link when the authorization supplied to the extension is null.
+   */
+
+  @Test
+  fun notUsedWhenAuthorizationIsNotBearerToken() {
+    val extension = BearerTokenExtension()
+    val file = File(TestDirectories.temporaryDirectory(), UUID.randomUUID().toString())
+
+    val request =
+      PlayerDownloadRequest(
+        uri = URI.create("urn:fake"),
+        credentials = null,
+        outputFile = file,
+        onProgress = {
+          this.logger.debug("progress: {}", it)
+        },
+        userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+      )
+
+    extension.authorization = null
+
+    val future =
+      extension.onDownloadLink(
+        statusExecutor = this.executor,
+        downloadProvider = this.downloadProvider,
+        originalRequest = request,
+        link = PlayerManifestLink.LinkBasic(
+          href = URI.create("urn:fake"),
+        )
+      )
+
+    Assertions.assertEquals(null, future)
+  }
+
+  /**
+   * The extension doesn't handle a link when the authorization supplied to the extension is not a
+   * bearer token.
+   */
+
+  @Test
+  fun notUsedWhenAuthorizationIsNull() {
+    val extension = BearerTokenExtension()
+    val file = File(TestDirectories.temporaryDirectory(), UUID.randomUUID().toString())
+
+    val request =
+      PlayerDownloadRequest(
+        uri = URI.create("urn:fake"),
+        credentials = null,
+        outputFile = file,
+        onProgress = {
+          this.logger.debug("progress: {}", it)
+        },
+        userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+      )
+
+    extension.authorization = LSHTTPAuthorizationBasic.ofUsernamePassword(
+      userName = "user",
+      password = "pw"
+    )
+
+    val future =
+      extension.onDownloadLink(
+        statusExecutor = this.executor,
+        downloadProvider = this.downloadProvider,
+        originalRequest = request,
+        link = PlayerManifestLink.LinkBasic(
+          href = URI.create("urn:fake"),
+        )
+      )
+
+    Assertions.assertEquals(null, future)
+  }
+
+  /**
+   * The extension doesn't handle a link when the original request has credentials.
+   */
+
+  @Test
+  fun notUsedWhenOriginalRequestHasCredentials() {
+    val extension = BearerTokenExtension()
+    val file = File(TestDirectories.temporaryDirectory(), UUID.randomUUID().toString())
+
+    val request =
+      PlayerDownloadRequest(
+        uri = URI.create("urn:fake"),
+        credentials = PlayerDownloadRequestCredentials.Basic(
+          user = "user",
+          password = "pw"
+        ),
+        outputFile = file,
+        onProgress = {
+          this.logger.debug("progress: {}", it)
+        },
+        userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+      )
+
+    extension.authorization = LSHTTPAuthorizationBearerToken.ofToken("abcd")
+
+    val future =
+      extension.onDownloadLink(
+        statusExecutor = this.executor,
+        downloadProvider = this.downloadProvider,
+        originalRequest = request,
+        link = PlayerManifestLink.LinkBasic(
+          href = URI.create("urn:fake"),
+        )
+      )
+
+    Assertions.assertEquals(null, future)
+  }
+
+  /**
+   * The extension doesn't handle a link that contains an encryption scheme.
+   */
+
+  @Test
+  fun notUsedWhenLinkHasEncryptionScheme() {
+    val extension = BearerTokenExtension()
+    val file = File(TestDirectories.temporaryDirectory(), UUID.randomUUID().toString())
+
+    val request =
+      PlayerDownloadRequest(
+        uri = URI.create("urn:fake"),
+        credentials = null,
+        outputFile = file,
+        onProgress = {
+          this.logger.debug("progress: {}", it)
+        },
+        userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+      )
+
+    extension.authorization = LSHTTPAuthorizationBearerToken.ofToken("abcd")
+
+    val future =
+      extension.onDownloadLink(
+        statusExecutor = this.executor,
+        downloadProvider = this.downloadProvider,
+        originalRequest = request,
+        link = PlayerManifestLink.LinkBasic(
+          href = URI.create("urn:fake"),
+          properties = PlayerManifestLinkProperties(
+            encrypted = PlayerManifestEncrypted(
+              scheme = "scheme1"
+            )
+          )
+        )
+      )
+
+    Assertions.assertEquals(null, future)
+  }
+
+  /**
+   * The extension sends the supplied bearer token.
+   */
+
+  @Test
+  fun testBearerTokenSent() {
+    val extension = BearerTokenExtension()
+    val file = File(TestDirectories.temporaryDirectory(), UUID.randomUUID().toString())
+
+    val request =
+      PlayerDownloadRequest(
+        uri = URI.create("urn:fake"),
+        credentials = null,
+        outputFile = file,
+        onProgress = {
+          this.logger.debug("progress: {}", it)
+        },
+        userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0")
+      )
+
+    extension.authorization = LSHTTPAuthorizationBearerToken.ofToken("abcd")
+
+    val future =
+      extension.onDownloadLink(
+        statusExecutor = this.executor,
+        downloadProvider = this.downloadProvider,
+        originalRequest = request,
+        link = PlayerManifestLink.LinkBasic(
+          href = URI.create("urn:fake"),
+        )
+      )
+
+    future!!.get()
+
+    val sentRequest = this.downloadProvider.requests.poll()
+    Assertions.assertEquals(request.uri, sentRequest.uri)
+    Assertions.assertEquals(request.outputFile, sentRequest.outputFile)
+    Assertions.assertTrue(sentRequest.credentials is PlayerDownloadRequestCredentials.BearerToken)
+
+    Assertions.assertEquals(
+      "abcd",
+      (sentRequest.credentials as PlayerDownloadRequestCredentials.BearerToken).token
+    )
+  }
+}

--- a/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/BearerTokenExtensionTest.kt
+++ b/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/BearerTokenExtensionTest.kt
@@ -1,0 +1,5 @@
+package org.librarysimplified.audiobook.tests.local
+
+import org.librarysimplified.audiobook.tests.open_access.BearerTokenExtensionContract
+
+class BearerTokenExtensionTest : BearerTokenExtensionContract()

--- a/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/LCPEngineProviderTest.kt
+++ b/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/LCPEngineProviderTest.kt
@@ -1,6 +1,9 @@
 package org.librarysimplified.audiobook.tests.local
 
 import android.content.Context
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import org.librarysimplified.audiobook.tests.R
 import org.librarysimplified.audiobook.tests.lcp.LCPEngineProviderContract
 import org.mockito.Mockito
 import org.slf4j.Logger
@@ -13,6 +16,10 @@ class LCPEngineProviderTest : LCPEngineProviderContract() {
 
   override fun context(): Context {
     val context = Mockito.mock(Context::class.java)
+
+    Mockito.`when`(context.getString(eq(R.string.player_manifest_audiobook_default_track_n), any()))
+      .thenReturn("Track #")
+
     return context
   }
 

--- a/org.librarysimplified.audiobook.tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/org.librarysimplified.audiobook.tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
**What's this do?**

This adds support for bearer token negotiation when downloading manifests, and for using the received token to download audio files. There are multiple parts:

- When downloading manifests, a [Palace HTTP client](https://github.com/ThePalaceProject/android-http) is now used, instead of using okhttp directly. The Palace HTTP client handles bearer token negotiation. When a download request results in a token document, the download is automatically retried with the received token. The client to be used is now supplied in the `ManifestFulfillmentBasicParameters` object, so that the calling application (e.g. android-core) can control the configuration of the client, and can re-use an existing client at its discretion.
- The `ManifestFulfilled` object now contains an `authorization` property, and `ManifestFulfillmentBasic` now uses it to report the bearer token that was negotiated by the HTTP client and used to complete the download of the manifest. This authorization can be stored by the caller (e.g. android-core), in order to use it to download audio files in the future.
- A new player extension, `BearerTokenExtension` has been implemented. This extension can be configured with a bearer token, and will inject that token into audio file downloads. This extension can be used by the caller (e.g. android-core) to supply a bearer token to be used for downloads. In practice, this will be the bearer token that was received during the manifest download, if there is one.

**Why are we doing this? (w/ JIRA link if applicable)**

This is needed to add support for BiblioBoard audiobooks, which use the bearer token download mechanism.

Notion: https://www.notion.so/lyrasis/Android-Error-downloading-BiblioBoard-audiobooks-03094266f26743fcb31f00b1de176b95

**How should this be tested? / Do these changes have associated tests?**

Unit tests are included. The demo player should continue to work. A PR to android-core is required, but once that's merged, BiblioBoard audiobooks should download and play successfully, and other audiobooks should continue to work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested downloads in the demo player and android-core.
