### PR TITLE
Updated image scale type

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,10 +175,11 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-17T05:03:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-06-14T16:52:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
-        <c:change date="2022-05-17T05:03:47+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
+        <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
+        <c:change date="2022-06-14T16:52:15+00:00" summary="Adjusted audiobook cover image scaling type"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -201,7 +201,7 @@
         android:layout_height="0dp"
         android:layout_margin="16dp"
         android:contentDescription="@string/audiobook_accessibility_book_cover"
-        android:scaleType="fitXY"
+        android:scaleType="fitCenter"
         android:src="@drawable/icon"
         app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
         app:layout_constraintEnd_toEndOf="parent"

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -201,7 +201,7 @@
         android:layout_height="0dp"
         android:layout_margin="16dp"
         android:contentDescription="@string/audiobook_accessibility_book_cover"
-        android:scaleType="centerCrop"
+        android:scaleType="fitXY"
         android:src="@drawable/icon"
         app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
**What's this do?**
This PR changes the _scaleType_ attribute in the player layout to _fitCenter_

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket](https://www.notion.so/lyrasis/Android-Cover-images-are-cropped-in-audiobook-player-eb8df9752f07497ab5ea8aa4d9b5234a) with a bug saying that some audiobooks' cover are cropped and not fully displayed to the user

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "OverDrive Integration Test Library" library
Search for "The Lost Symbol" audiobook
Verify the [audiobook cover is not cropped](https://user-images.githubusercontent.com/79104027/173633845-b39b91c4-8fbf-4533-8b58-eb3f285ae7f8.png)

[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 