### PR TITLE
Added support to bookmarks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,11 +175,13 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-06-14T16:52:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-06-30T13:31:27+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
-        <c:change date="2022-06-14T16:52:15+00:00" summary="Adjusted audiobook cover image scaling type"/>
+        <c:change date="2022-06-14T00:00:00+00:00" summary="Adjusted audiobook cover image scaling type"/>
+        <c:change date="2022-06-30T00:00:00+00:00" summary="Added support to bookmarks"/>
+        <c:change date="2022-06-30T13:31:27+00:00" summary="Changed audiobook behaviour to not start automatically playing"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerEvent.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerEvent.kt
@@ -60,6 +60,16 @@ sealed class PlayerEvent {
     ) : PlayerEventWithSpineElement()
 
     /**
+     * The given spine item is ready to be played, but waiting for the user's action since it
+     * won't automatically start playing.
+     */
+
+    data class PlayerEventPlaybackWaitingForAction(
+      override val spineElement: PlayerSpineElementType,
+      val offsetMilliseconds: Long
+    ) : PlayerEventWithSpineElement()
+
+    /**
      * The given spine item is playing, and this event is a progress update indicating how far
      * along playback is.
      */

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
@@ -131,7 +131,8 @@ interface PlayerType : AutoCloseable {
    */
 
   fun movePlayheadToLocation(
-    location: PlayerPosition
+    location: PlayerPosition,
+    playAutomatically: Boolean
   )
 
   /**

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -23,6 +23,7 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackWaitingForAction
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSleepTimer
@@ -550,7 +551,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     this.playerInitialized = true
 
     val lastPlayed = this.bookmarks.bookmarkFindLastReadLocation(book.id.value)
-    this.player.movePlayheadToLocation(lastPlayed)
+    this.player.movePlayheadToLocation(lastPlayed, playAutomatically = false)
     this.playerEvents = this.player.events.subscribe(this::onPlayerEvent)
 
     this.startAllPartsDownloading()
@@ -762,7 +763,8 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
       is PlayerEventPlaybackPaused,
       is PlayerEventPlaybackProgressUpdate,
       is PlayerEventPlaybackStarted,
-      is PlayerEventPlaybackStopped ->
+      is PlayerEventPlaybackStopped,
+      is PlayerEventPlaybackWaitingForAction ->
         Unit
     }
   }

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
@@ -119,7 +119,7 @@ class MockingPlayer(private val book: MockingAudioBook) : PlayerType {
 
   override fun movePlayheadToBookStart() {
     this.log.debug("movePlayheadToBookStart")
-    this.movePlayheadToLocation(this.book.spineItems.first().position)
+    this.movePlayheadToLocation(this.book.spineItems.first().position, playAutomatically = true)
   }
 
   private fun goToChapter(chapter: Int) {
@@ -132,7 +132,7 @@ class MockingPlayer(private val book: MockingAudioBook) : PlayerType {
     }
   }
 
-  override fun movePlayheadToLocation(location: PlayerPosition) {
+  override fun movePlayheadToLocation(location: PlayerPosition, playAutomatically: Boolean) {
     this.log.debug("movePlayheadToLocation {} {} {}", location.part, location.chapter, location.offsetMilliseconds)
     this.callEvents.onNext("movePlayheadToLocation ${location.part} ${location.chapter} ${location.offsetMilliseconds}")
     this.goToChapter(location.chapter)

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -14,6 +14,7 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackWaitingForAction
 import org.librarysimplified.audiobook.api.PlayerType
 import org.slf4j.LoggerFactory
 import rx.Subscription
@@ -54,7 +55,8 @@ class ExoBookmarkObserver private constructor(
       is PlayerEventPlaybackBuffering,
       is PlayerEventPlaybackPaused,
       is PlayerEventPlaybackStarted,
-      is PlayerEventPlaybackStopped ->
+      is PlayerEventPlaybackStopped,
+      is PlayerEventPlaybackWaitingForAction ->
         Unit
     }
   }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
@@ -25,6 +25,7 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStopped
+import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackWaitingForAction
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadFailed
@@ -827,6 +828,8 @@ abstract class ExoEngineProviderContract {
         "playbackChapterCompleted ${event.spineElement.index}"
       is PlayerEventChapterWaiting ->
         "playbackChapterWaiting ${event.spineElement.index}"
+      is PlayerEventPlaybackWaitingForAction ->
+        "playbackWaitingForAction ${event.spineElement.index} ${event.offsetMilliseconds}"
       is PlayerEventPlaybackPaused ->
         "playbackPaused ${event.spineElement.index} ${event.offsetMilliseconds}"
       is PlayerEventPlaybackStopped ->

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -105,80 +105,106 @@
         app:layout_constraintTop_toBottomOf="@id/player_time"
         tools:text="Very, very, very long placeholder text that should never be seen in practice." />
 
-    <ImageView
-        android:id="@+id/player_play_button"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/player_commands"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <ImageView
+            android:id="@+id/player_play_button"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginBottom="16dp"
+            android:contentDescription="@string/audiobook_accessibility_play"
+            android:src="@drawable/play_icon"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:tint="?attr/simplifiedColorControlIcon"
+            app:tintMode="src_in" />
+
+        <ImageView
+            android:id="@+id/player_jump_backwards"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:contentDescription="@string/audiobook_accessibility_backward_15"
+            android:src="@drawable/circle_arrow_backward"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/player_play_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:tint="?attr/simplifiedColorControlIcon"
+            app:tintMode="src_in" />
+
+        <TextView
+            android:id="@+id/player_jump_forwards_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:focusable="false"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:text="@string/audiobook_player_seek_15"
+            android:textColor="?attr/simplifiedColorControlIcon"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/player_jump_forwards"
+            app:layout_constraintEnd_toEndOf="@id/player_jump_forwards"
+            app:layout_constraintStart_toStartOf="@id/player_jump_forwards"
+            app:layout_constraintTop_toTopOf="@id/player_jump_forwards" />
+
+        <ImageView
+            android:id="@+id/player_jump_forwards"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="32dp"
+            android:layout_marginBottom="16dp"
+            android:contentDescription="@string/audiobook_accessibility_forward_15"
+            android:src="@drawable/circle_arrow_forward"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/player_play_button"
+            app:tint="?attr/simplifiedColorControlIcon"
+            app:tintMode="src_in" />
+
+        <TextView
+            android:id="@+id/player_jump_backwards_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:focusable="false"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:text="@string/audiobook_player_seek_15"
+            android:textColor="?attr/simplifiedColorControlIcon"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/player_jump_backwards"
+            app:layout_constraintEnd_toEndOf="@id/player_jump_backwards"
+            app:layout_constraintStart_toStartOf="@id/player_jump_backwards"
+            app:layout_constraintTop_toTopOf="@id/player_jump_backwards" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/bottom_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="player_commands,player_downloading_chapter" />
+
+    <ProgressBar
+        android:id="@+id/player_downloading_chapter"
         android:layout_width="64dp"
         android:layout_height="64dp"
         android:layout_marginBottom="16dp"
-        android:contentDescription="@string/audiobook_accessibility_play"
-        android:src="@drawable/play_icon"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in" />
-
-    <ImageView
-        android:id="@+id/player_jump_backwards"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginEnd="32dp"
-        android:layout_marginBottom="16dp"
-        android:contentDescription="@string/audiobook_accessibility_backward_15"
-        android:src="@drawable/circle_arrow_backward"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/player_play_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in" />
-
-    <TextView
-        android:id="@+id/player_jump_forwards_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:clickable="false"
-        android:focusable="false"
-        android:gravity="center"
-        android:importantForAccessibility="no"
-        android:text="@string/audiobook_player_seek_15"
-        android:textColor="?attr/simplifiedColorControlIcon"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@id/player_jump_forwards"
-        app:layout_constraintEnd_toEndOf="@id/player_jump_forwards"
-        app:layout_constraintStart_toStartOf="@id/player_jump_forwards"
-        app:layout_constraintTop_toTopOf="@id/player_jump_forwards" />
-
-    <ImageView
-        android:id="@+id/player_jump_forwards"
-        android:layout_width="64dp"
-        android:layout_height="64dp"
-        android:layout_marginStart="32dp"
-        android:layout_marginBottom="16dp"
-        android:contentDescription="@string/audiobook_accessibility_forward_15"
-        android:src="@drawable/circle_arrow_forward"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/player_play_button"
-        app:tint="?attr/simplifiedColorControlIcon"
-        app:tintMode="src_in" />
-
-    <TextView
-        android:id="@+id/player_jump_backwards_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:clickable="false"
-        android:focusable="false"
-        android:gravity="center"
-        android:importantForAccessibility="no"
-        android:text="@string/audiobook_player_seek_15"
-        android:textColor="?attr/simplifiedColorControlIcon"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@id/player_jump_backwards"
-        app:layout_constraintEnd_toEndOf="@id/player_jump_backwards"
-        app:layout_constraintStart_toStartOf="@id/player_jump_backwards"
-        app:layout_constraintTop_toTopOf="@id/player_jump_backwards" />
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/player_waiting_buffering"
@@ -191,7 +217,7 @@
         android:text="@string/audiobook_player_waiting"
         android:textSize="14sp"
         android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@id/player_play_button"
+        app:layout_constraintBottom_toTopOf="@id/bottom_barrier"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 


### PR DESCRIPTION
**What's this do?**
This PR adds support to the audiobook bookmarks that are pending on the Palace app. The bookmarks may be set to a chapter  and offset that haven't been yet downloaded, so there's the need of showing that information to the user. For that matter, a loading animation replaces the play/pause and forward/rewind commands while it's being downloaded. After that, the player commands are shown again and the loading animation is gone.
When this happens, there's also the need of saving the current bookmark's offset so the player can start playing in the correct offset. Once everything's ready, the player should be set to the bookmark's offset and shouldn't be automatically played, so this PR also adds logic to prevent that from happening.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a Palace project [feature request to support audiobook bookmarks](https://www.notion.so/lyrasis/Android-Sync-audiobook-listening-position-to-server-d0937223853c40da932ba0d972723189). In order to do this, there are some changes that need to be performed in this module. Also, there's [a bug saying the player shouldn't start playing automatically](https://www.notion.so/lyrasis/Android-The-audiobooks-start-playing-automatically-after-tapping-Listen-69c3c3d6bc4c4f6fa9622e75e300ca41), and since the bookmark needed changes would affect that logic the PR also covers that.

**How should this be tested? / Do these changes have associated tests?**
The audiobook bookmark main testing can only be performed in [this Palace PR](https://github.com/ThePalaceProject/android-core/pull/120), but the player not starting automatically playing can be tested by opening the demo, select any of the available books and confirm it's not being played.

**Dependencies for merging? Releasing to production?**
Although this module or changes don't rely on the audiobook bookmarks to be implemented, this is related to [this PR](https://github.com/ThePalaceProject/android-core/pull/120).

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 