### PR TITLE
Added 'Cancel' option to player settings dialogs.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,14 +175,15 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-08T09:43:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-15T17:37:03+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
         <c:change date="2022-06-14T00:00:00+00:00" summary="Adjusted audiobook cover image scaling type"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Added support to bookmarks"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Changed audiobook behaviour to not start automatically playing"/>
-        <c:change date="2022-07-08T09:43:44+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
+        <c:change date="2022-07-08T00:00:00+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
+        <c:change date="2022-07-15T17:37:03+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -37,14 +38,23 @@ class PlayerPlaybackRateFragment : DialogFragment() {
     state: Bundle?
   ): View {
 
-    val view: RecyclerView =
-      inflater.inflate(R.layout.player_rate_view, container, false) as RecyclerView
+    val view: ViewGroup =
+      inflater.inflate(R.layout.player_rate_view, container, false) as ViewGroup
 
+    val list: RecyclerView =
+      view.findViewById(R.id.list)
     this.dialog?.setTitle(R.string.audiobook_player_menu_playback_rate_title)
 
-    view.layoutManager = LinearLayoutManager(view.context)
-    view.setHasFixedSize(true)
-    view.adapter = this.adapter
+    list.layoutManager = LinearLayoutManager(view.context)
+    list.setHasFixedSize(true)
+    list.adapter = this.adapter
+
+    val cancelButton: TextView =
+      view.findViewById(R.id.cancel_button)
+
+    cancelButton.setOnClickListener {
+      dismiss()
+    }
 
     return view
   }
@@ -53,7 +63,7 @@ class PlayerPlaybackRateFragment : DialogFragment() {
     super.onAttach(context)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
+      requireArguments().getSerializable(parametersKey)
       as PlayerFragmentParameters
 
     if (context is PlayerFragmentListenerType) {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerConfiguration.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerConfiguration.kt
@@ -46,5 +46,5 @@ enum class PlayerSleepTimerConfiguration {
    * The sleep timer will finish at the end of the current chapter.
    */
 
-  END_OF_CHAPTER,
+  END_OF_CHAPTER
 }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -47,14 +48,23 @@ class PlayerSleepTimerFragment : DialogFragment() {
     state: Bundle?
   ): View {
 
-    val view: RecyclerView =
-      inflater.inflate(R.layout.player_sleep_timer_view, container, false) as RecyclerView
+    val view: ViewGroup =
+      inflater.inflate(R.layout.player_sleep_timer_view, container, false) as ViewGroup
 
+    val list: RecyclerView =
+      view.findViewById(R.id.list)
     this.dialog?.setTitle(R.string.audiobook_player_menu_sleep_title)
 
-    view.layoutManager = LinearLayoutManager(view.context)
-    view.setHasFixedSize(true)
-    view.adapter = this.adapter
+    list.layoutManager = LinearLayoutManager(view.context)
+    list.setHasFixedSize(true)
+    list.adapter = this.adapter
+
+    val cancelButton: TextView =
+      view.findViewById(R.id.cancel_button)
+
+    cancelButton.setOnClickListener {
+      dismiss()
+    }
 
     return view
   }
@@ -63,7 +73,7 @@ class PlayerSleepTimerFragment : DialogFragment() {
     super.onAttach(context)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
+      requireArguments().getSerializable(parametersKey)
       as PlayerFragmentParameters
 
     if (context is PlayerFragmentListenerType) {
@@ -100,7 +110,7 @@ class PlayerSleepTimerFragment : DialogFragment() {
 
   private fun enabledSleepTimerConfigurations(): List<PlayerSleepTimerConfiguration> {
     val nowEnabled =
-      this.context!!.resources.getBoolean(R.bool.audiobook_player_debug_sleep_timer_now_enabled)
+      requireContext().resources.getBoolean(R.bool.audiobook_player_debug_sleep_timer_now_enabled)
     return values().toList().filter { configuration ->
       when (configuration) {
         MINUTES_15, MINUTES_30, MINUTES_45, MINUTES_60, OFF, END_OF_CHAPTER -> true

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_item_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_item_view.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="80dp">
-
-  <ImageView
-    android:id="@+id/player_rate_item_view_separator"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="1dp"
-    android:layout_alignParentTop="true"
-    android:layout_centerHorizontal="true"
-    android:focusable="false"
-    android:clickable="false"
-    android:src="@drawable/player_rate_item_separator" />
+    android:layout_height="80dp">
 
-  <TextView
-    android:id="@+id/player_rate_item_view_name"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerInParent="true"
-    android:layout_margin="12dp"
-    android:text="Placeholder"
-    android:textAlignment="center"
-    android:textSize="24sp" />
+    <ImageView
+        android:id="@+id/player_rate_item_view_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:clickable="false"
+        android:focusable="false"
+        android:src="@drawable/player_rate_item_separator" />
 
+    <TextView
+        android:id="@+id/player_rate_item_view_name"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="12dp"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        tools:text="Placeholder" />
 
 </RelativeLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_view.xml
@@ -1,16 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorBackgroundFloating"
+    android:orientation="vertical">
 
-<androidx.recyclerview.widget.RecyclerView
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:background="?attr/colorBackgroundFloating"
-  android:id="@+id/list"
-  android:name="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:paddingTop="16dp"
-  app:layoutManager="LinearLayoutManager"
-  tools:context="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
-  tools:listitem="@layout/player_rate_item_view" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:name="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        app:layoutManager="LinearLayoutManager"
+        tools:context="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
+        tools:listitem="@layout/player_rate_item_view" />
+
+    <TextView
+        android:id="@+id/cancel_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="24sp"
+        android:text="@string/audiobook_player_options_cancel" />
+
+</LinearLayout>
 

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_item_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_item_view.xml
@@ -1,31 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="80dp">
-
-  <ImageView
-    android:id="@+id/player_sleep_item_view_separator"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="1dp"
-    android:layout_alignParentTop="true"
-    android:layout_centerHorizontal="true"
-    android:importantForAccessibility="no"
-    android:focusable="false"
-    android:clickable="false"
-    android:src="@drawable/player_sleep_item_separator" />
+    android:layout_height="80dp">
 
-  <TextView
-    android:id="@+id/player_sleep_item_view_name"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerInParent="true"
-    android:importantForAccessibility="no"
-    android:focusable="false"
-    android:clickable="false"
-    android:layout_margin="12dp"
-    android:text="Placeholder"
-    android:textAlignment="center"
-    android:textSize="24sp" />
+    <ImageView
+        android:id="@+id/player_sleep_item_view_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:clickable="false"
+        android:focusable="false"
+        android:src="@drawable/player_rate_item_separator" />
+
+    <TextView
+        android:id="@+id/player_sleep_item_view_name"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="12dp"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        tools:text="Placeholder" />
 
 </RelativeLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_timer_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_timer_view.xml
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorBackgroundFloating"
+    android:orientation="vertical">
 
-<androidx.recyclerview.widget.RecyclerView
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:background="?attr/colorBackgroundFloating"
-  android:id="@+id/list"
-  android:name="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:paddingTop="16dp"
-  app:layoutManager="LinearLayoutManager"
-  tools:context="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
-  tools:listitem="@layout/player_sleep_item_view" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:name="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        app:layoutManager="LinearLayoutManager"
+        tools:context="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
+        tools:listitem="@layout/player_sleep_item_view" />
+
+    <TextView
+        android:id="@+id/cancel_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="24sp"
+        android:text="@string/audiobook_player_options_cancel" />
+
+</LinearLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
   <string name="audiobook_player_sleep_off">Off</string>
   <string name="audiobook_player_seek_15">15</string>
 
+  <string name="audiobook_player_options_cancel">Cancel</string>
+
   <string name="audiobook_player_buffering">Buffering…</string>
   <string name="audiobook_player_waiting">File %1$d must be downloaded to continue playback.</string>
   <string name="audiobook_player_error">An error occurred during playback. Error code: %1$d</string>


### PR DESCRIPTION
**What's this do?**
This PR adds a "Cancel" option to the library selection dialog

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=7669bb698f0b4f7486211f75d6170b17&p=157fa0c2bdac427292d6e74ce240dd98) to make this change so it gets similar to the iOS version of the app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Open the sleep timer option
Verify [there's a "Cancel" option at the bottom of the dialog](https://user-images.githubusercontent.com/79104027/179279995-3efd9dd2-8352-4b6b-8503-4132c5ee3615.png)
Click on it and verify the dialog closes
Open the playback rate option
Verify [there's a "Cancel" option at the bottom of the dialog](https://user-images.githubusercontent.com/79104027/179279559-f7558658-d52e-40c3-ade7-fb572651d6ef.png)
Click on it and verify the dialog closes

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 