### PR TITLE
Disabled click on audiobook seekbar

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,14 +175,15 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-08T09:43:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-18T10:47:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
         <c:change date="2022-06-14T00:00:00+00:00" summary="Adjusted audiobook cover image scaling type"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Added support to bookmarks"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Changed audiobook behaviour to not start automatically playing"/>
-        <c:change date="2022-07-08T09:43:44+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
+        <c:change date="2022-07-08T00:00:00+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
+        <c:change date="2022-07-18T10:47:05+00:00" summary="Disabled click on audiobook seekbar."/>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
This PR detects the touch events on the audiobook seekbar and determines if the click was on the thumb (the element that indicates the current progress of the audiobook) or not. If it was, then it checks if the user is moving the seekbar thumb or not. If it wasn't, then the event is ignored. In case the user is moving the thumb, then it will properly handle it by moving the progress to where the user is dragging it. In case they aren't moving the thumb, the event is ignored.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a feature request to do this so the user doesn't click on the seekbar by accident and moves the current audiobook progress and loses their current progress on the audiobook.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Click on different areas of the seekbar and verify the progress does not move
Drag the seekbar thumg and verify the progress moves

_Note: If the click is really close to the seekbar, it may consider it to be a dragging movement. It depends on how close your finger is to the thumb_

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 