### PR TITLE
Updated audiobook playback rate with saved value

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-18T10:47:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-19T10:40:12+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -183,8 +183,9 @@
         <c:change date="2022-06-30T00:00:00+00:00" summary="Added support to bookmarks"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Changed audiobook behaviour to not start automatically playing"/>
         <c:change date="2022-07-08T00:00:00+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
-        <c:change date="2022-07-15T17:37:03+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
-        <c:change date="2022-07-18T10:47:05+00:00" summary="Disabled click on audiobook seekbar."/>
+        <c:change date="2022-07-15T00:00:00+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
+        <c:change date="2022-07-18T00:00:00+00:00" summary="Disabled click on audiobook seekbar."/>
+        <c:change date="2022-07-19T10:40:12+00:00" summary="Updated audiobook playback rate with saved value."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
@@ -493,8 +493,6 @@ class LCPAudioBookPlayer private constructor(
     this.exoPlayer.prepare(this.exoAudioRenderer)
     this.seek(offset)
     this.exoPlayer.playWhenReady = playAutomatically
-
-    this.setPlayerPlaybackRate(this.currentPlaybackRate)
   }
 
   private fun seek(offsetMs: Long) {

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -606,8 +606,6 @@ class ExoAudioBookPlayer private constructor(
     this.exoPlayer.prepare(this.exoAudioRenderer)
     this.seek(offset)
     this.exoPlayer.playWhenReady = playAutomatically
-
-    this.setPlayerPlaybackRate(this.currentPlaybackRate)
   }
 
   private fun seek(offsetMs: Long) {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -149,6 +149,8 @@ class PlayerFragment : Fragment() {
         as PlayerFragmentParameters
     this.timeStrings =
       PlayerTimeStrings.SpokenTranslations.createFromResources(this.resources)
+
+    this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
   }
 
   override fun onAttach(context: Context) {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
@@ -1,6 +1,8 @@
 package org.librarysimplified.audiobook.views
 
 import androidx.annotation.ColorInt
+import org.librarysimplified.audiobook.api.PlayerPlaybackRate
+import org.librarysimplified.audiobook.api.PlayerPlaybackRate.NORMAL_TIME
 import java.io.Serializable
 
 /**
@@ -17,5 +19,8 @@ data class PlayerFragmentParameters(
     message = "Colors should now be taken from the colorPrimary attribute of the current application theme",
     level = DeprecationLevel.WARNING
   )
-  @ColorInt val primaryColor: Int? = null
+  @ColorInt val primaryColor: Int? = null,
+
+  val currentRate: PlayerPlaybackRate? = NORMAL_TIME
+
 ) : Serializable


### PR DESCRIPTION
**What's this do?**
This PR adds logic to retrieve a saved playback rate as a parameter of the PlayerFragment and then restore it on the players by changing the player's current playback rate.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a ticket with a bug](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=7669bb698f0b4f7486211f75d6170b17&p=0f3ab653edd54965bc9f9280702eea47) that says the audiobook's playback rate is not saved when the user closes the book and they need to set it again when reopening the book.

**How should this be tested? / Do these changes have associated tests?**
_This can only be tested when [this PR](https://github.com/ThePalaceProject/android-core/pull/125) is merged_:

Open the Palace app
Open the _Daykeeper_ audiobook from Lyrasis Reads
Change the playback rate to a different value
Close the audiobook
Reopen the audiobook and verify the rate is the you previously select

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/125) needs to be merged in order to fetch a saved playback rate

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 