### PR TITLE
Fixed audiobook not playing from correct position after dragging seekbar

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-18T10:47:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-20T15:21:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -183,8 +183,9 @@
         <c:change date="2022-06-30T00:00:00+00:00" summary="Added support to bookmarks"/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Changed audiobook behaviour to not start automatically playing"/>
         <c:change date="2022-07-08T00:00:00+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
-        <c:change date="2022-07-15T17:37:03+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
-        <c:change date="2022-07-18T10:47:05+00:00" summary="Disabled click on audiobook seekbar."/>
+        <c:change date="2022-07-15T00:00:00+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
+        <c:change date="2022-07-18T00:00:00+00:00" summary="Disabled click on audiobook seekbar."/>
+        <c:change date="2022-07-20T15:21:54+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -548,14 +548,6 @@ class PlayerFragment : Fragment() {
     return this.playerPosition.thumb.bounds.contains(event.x.toInt(), event.y.toInt())
   }
 
-  private fun onProgressBarDraggingStarted() {
-    this.log.debug("onProgressBarDraggingStarted")
-  }
-
-  private fun onProgressBarChanged(progress: Int, fromUser: Boolean) {
-    this.log.debug("onProgressBarChanged: {} {}", progress, fromUser)
-  }
-
   private fun onPlayerEventsCompleted() {
     this.log.debug("onPlayerEventsCompleted")
   }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -478,19 +478,6 @@ class PlayerFragment : Fragment() {
     this.playerPosition = view.findViewById(R.id.player_progress)!!
     this.playerPosition.isEnabled = false
     this.playerPositionDragging = false
-    this.playerPosition.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
-      override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-        this@PlayerFragment.onProgressBarChanged(progress, fromUser)
-      }
-
-      override fun onStartTrackingTouch(seekBar: SeekBar) {
-        this@PlayerFragment.onProgressBarDraggingStarted()
-      }
-
-      override fun onStopTrackingTouch(seekBar: SeekBar) {
-        this@PlayerFragment.onProgressBarDraggingStopped()
-      }
-    })
 
     this.playerPosition.setOnTouchListener { _, event -> handleTouchOnSeekbar(event) }
 
@@ -517,8 +504,12 @@ class PlayerFragment : Fragment() {
         }
       }
       MotionEvent.ACTION_UP -> {
+        val wasDragging = playerPositionDragging
         playerPositionDragging = false
         return if (wasSeekbarThumbClicked(event)) {
+          if (wasDragging) {
+            onProgressBarDraggingStopped()
+          }
           playerPosition.onTouchEvent(event)
         } else {
           true


### PR DESCRIPTION
**What's this do?**
This PR updates the way the player handles the ACTION_UP touch event. If the user was dragging the seekbar before lifting their finger, then we need to call the method that updates the player when the dragging is completed.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a bug reported in one of [this task's comments](https://www.notion.so/lyrasis/Android-Audiobooks-need-to-change-player-to-require-dragging-time-bar-to-skip-forward-or-back-in-tr-eb232027287d476eb3c144436b9adfba) saying that after completing the seekbar dragging, nothing happens in terms of updating the player's playing offset.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace App
Open any audiobook
Drag the seekbar to a different offset
Verify the player updates the playing offset to the new position

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 