### PR TITLE
Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-20T15:21:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-21T15:38:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -185,8 +185,9 @@
         <c:change date="2022-07-08T00:00:00+00:00" summary="Updated PlayerPositions method to support new audiobook bookmark version"/>
         <c:change date="2022-07-15T00:00:00+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
         <c:change date="2022-07-18T00:00:00+00:00" summary="Disabled click on audiobook seekbar."/>
-        <c:change date="2022-07-19T10:40:12+00:00" summary="Updated audiobook playback rate with saved value."/>
-        <c:change date="2022-07-20T15:21:54+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
+        <c:change date="2022-07-19T00:00:00+00:00" summary="Updated audiobook playback rate with saved value."/>
+        <c:change date="2022-07-20T00:00:00+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
+        <c:change date="2022-07-21T15:38:15+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_rate_view.xml
@@ -11,7 +11,8 @@
         android:id="@+id/list"
         android:name="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:paddingTop="8dp"
         app:layoutManager="LinearLayoutManager"
         tools:context="org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment"
@@ -21,9 +22,8 @@
         android:id="@+id/cancel_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:gravity="center"
-        android:padding="16dp"
+        android:padding="24dp"
         android:textSize="24sp"
         android:text="@string/audiobook_player_options_cancel" />
 

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_timer_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_sleep_timer_view.xml
@@ -11,7 +11,8 @@
         android:id="@+id/list"
         android:name="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:paddingTop="8dp"
         app:layoutManager="LinearLayoutManager"
         tools:context="org.librarysimplified.audiobook.views.PlayerSleepTimerFragment"
@@ -21,9 +22,8 @@
         android:id="@+id/cancel_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:gravity="center"
-        android:padding="16dp"
+        android:padding="24dp"
         android:textSize="24sp"
         android:text="@string/audiobook_player_options_cancel" />
 


### PR DESCRIPTION
**What's this do?**
This PR changes the height of the sleep timer and playback rate dialog's list of options so the "Cancel" button can also be displayed and clickable.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a comment in a bug ticket](https://www.notion.so/lyrasis/Android-There-are-no-Cancel-buttons-on-Adding-libraries-from-logo-Sleep-timer-and-Playback--157fa0c2bdac427292d6e74ce240dd98) saying that the dialog is just displaying an empty block at the bottom of the dialog and it's not even clickable

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Click on the sleep timer option at the top
Verify [the "Cancel" is there](https://user-images.githubusercontent.com/79104027/180256593-adf082ae-af4a-403e-a217-544dcfe6a5d7.png), click on it and verify the dialog has closed
Click on the playback rate option at the top
Verify [the "Cancel" is there](https://user-images.githubusercontent.com/79104027/180256701-1f29df6e-fc5f-4931-87dc-cb0626341bc4.png), click on it and verify the dialog has closed

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 