### PR TITLE
Bugfix/fix chaotical chapter downloading on click

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-21T15:38:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-23T11:35:01+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -187,7 +187,8 @@
         <c:change date="2022-07-18T00:00:00+00:00" summary="Disabled click on audiobook seekbar."/>
         <c:change date="2022-07-19T00:00:00+00:00" summary="Updated audiobook playback rate with saved value."/>
         <c:change date="2022-07-20T00:00:00+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
-        <c:change date="2022-07-21T15:38:15+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
+        <c:change date="2022-07-21T00:00:00+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
+        <c:change date="2022-07-23T11:35:01+00:00" summary="Fixed chaotical chapter downloading after clicking on a specific chapter to download"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBook.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBook.kt
@@ -162,7 +162,7 @@ class ExoAudioBook private constructor(
       }.map { entry ->
 
         val originalLink = entry.key
-        val spineItems = entry.value.mapIndexed { index, manifestSpineItem ->
+        val spineItems = entry.value.map { manifestSpineItem ->
 
           val duration =
             manifestSpineItem.duration?.let { time ->
@@ -173,7 +173,7 @@ class ExoAudioBook private constructor(
             downloadStatusEvents = statusEvents,
             bookID = bookId,
             itemManifest = manifestSpineItem,
-            index = index,
+            index = manifestIndex,
             nextElement = null,
             previousElement = spineItemPrevious,
             duration = duration

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadTask.kt
@@ -112,7 +112,7 @@ class ExoDownloadTask(
           this@ExoDownloadTask.onDownloadCompleted()
         }
 
-        override fun onFailure(exception: Throwable?) {
+        override fun onFailure(exception: Throwable) {
           when (exception) {
             is CancellationException ->
               this@ExoDownloadTask.onDownloadCancelled()

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoDownloadWholeBookTask.kt
@@ -1,7 +1,12 @@
 package org.librarysimplified.audiobook.open_access
 
 import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
+import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
+import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloaded
+import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadFailed
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
+import org.slf4j.LoggerFactory
+import rx.Subscription
 
 /**
  * An Exo implementation of the download-whole-book task.
@@ -11,21 +16,104 @@ class ExoDownloadWholeBookTask(
   private val audioBook: ExoAudioBook
 ) : PlayerDownloadWholeBookTaskType {
 
+  private val log = LoggerFactory.getLogger(ExoDownloadWholeBookTask::class.java)
+
+  private var downloadEventsSubscription: Subscription? = null
+
+  private var currentDownloadTaskIndex = 0
+  private var currentFileName = ""
+
+  init {
+    this.downloadEventsSubscription =
+      this.audioBook.spineElementDownloadStatus.subscribe(
+        { event -> this.onDownloadStatusUpdated(event) },
+        { error -> this.onDownloadError(error) }
+      )
+  }
+
   override fun fetch() {
-    this.audioBook.downloadTasks.forEach { task ->
-      task.fetch()
-    }
+    currentDownloadTaskIndex = 0
+    fetchCurrentDownloadTask()
   }
 
   override fun cancel() {
     this.audioBook.downloadTasks.forEach { task ->
-      task.cancel()
-    }
+      if (task.spineItems.filterIsInstance<ExoSpineElement>().any { item ->
+          item.downloadStatus !is PlayerSpineElementDownloaded
+        }) {
+          task.cancel()
+        }
+      }
+
+    downloadEventsSubscription?.unsubscribe()
   }
 
   override fun delete() {
     this.audioBook.downloadTasks.forEach { task ->
       task.delete()
+    }
+
+    downloadEventsSubscription?.unsubscribe()
+  }
+
+  private fun fetchCurrentDownloadTask() {
+    if (currentDownloadTaskIndex >= this.audioBook.downloadTasks.size) {
+      return
+    }
+
+    val task = this.audioBook.downloadTasks[currentDownloadTaskIndex]
+    currentFileName = task.partFile.name
+
+    if (!task.spineItems.all { item -> item.downloadStatus is PlayerSpineElementDownloaded }) {
+      task.fetch()
+    } else {
+      currentDownloadTaskIndex++
+      fetchCurrentDownloadTask()
+    }
+  }
+
+  private fun onDownloadError(error: Throwable) {
+    this.log.error("onDownloadError: error: ", error)
+    return
+  }
+
+  private fun onDownloadStatusUpdated(status: PlayerSpineElementDownloadStatus) {
+    val element = status.spineElement
+    val downloadTask = this.audioBook.downloadTasks.firstOrNull { task ->
+      task.fulfillsSpineElement(element)
+    }
+
+    if (downloadTask == null) {
+      this.log.error("[{}]: onDownloadStatusUpdated: no download task available", element.id)
+      return
+    }
+
+    when (status) {
+      is PlayerSpineElementDownloaded -> {
+        this.log.debug("[{}]: onDownloadStatusUpdated: completed downloading task", element.id)
+        startNextTaskIfOnSequence(downloadTask.partFile.name)
+      }
+      is PlayerSpineElementDownloadFailed -> {
+        this.log.error("[{}]: onDownloadStatusUpdated: failed downloading task", element.id)
+        startNextTaskIfOnSequence(downloadTask.partFile.name)
+      }
+      else -> {
+        this.log.debug("[{}]: onDownloadStatusUpdated: {}", element.id, status)
+      }
+    }
+  }
+
+  private fun startNextTaskIfOnSequence(fileName: String) {
+
+    // the user can download a chapter ahead of the current order, so we need to check if
+    // we should move on with the next task in the sequence or not. If the file name is equal
+    // to the file name set at the beginning of the task, it means the download started from
+    // the "whole book task" sequence and we can advance. Otherwise, it means the task that
+    // was completed was started by the user and we can't increment the variable and start a
+    // new task because it would cause a weird behavior on the downloading tasks and UI
+    if (currentFileName == fileName) {
+      currentDownloadTaskIndex++
+      fetchCurrentDownloadTask()
     }
   }
 

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ExoUriDownloadProvider.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ExoUriDownloadProvider.kt
@@ -7,25 +7,29 @@ import org.librarysimplified.audiobook.api.PlayerDownloadRequest
 import java.net.URI
 
 /**
- * An implementation of the {@link PlayerDownloadProviderType} interface that receives a map with
- * the URIs that will be downloaded and the number of times they were downloaded.
+ * An implementation of the {@link PlayerDownloadProviderType} interface that receives a
+ * method to call when the request is made and a map with the URIs that will be downloaded
+ * and the number of times they were downloaded.
  */
 
-class ExoUriDownloadProvider(private val downloadTimes: HashMap<URI, Int>) :
+class ExoUriDownloadProvider(private val onRequestSuccessfullyCompleted: (URI) -> Unit,
+                             private val uriDownloadTimes: HashMap<URI, Int>) :
   PlayerDownloadProviderType {
 
   override fun download(request: PlayerDownloadRequest): ListenableFuture<Unit> {
 
-    val numberOfTimesUriWasDownloaded = downloadTimes[request.uri]
+    val numberOfTimesUriWasDownloaded = uriDownloadTimes[request.uri]
 
     // check if this URI is in the map and if it's not add it with
     if (numberOfTimesUriWasDownloaded == null) {
-      downloadTimes[request.uri] = 0
+      uriDownloadTimes[request.uri] = 0
 
       // the URI is on the list, so we increment the number of times it was downloaded
     } else {
-      downloadTimes[request.uri] = numberOfTimesUriWasDownloaded + 1
+      uriDownloadTimes[request.uri] = numberOfTimesUriWasDownloaded + 1
     }
+
+    onRequestSuccessfullyCompleted(request.uri)
 
     return ListenableFutureTask.create(
       {


### PR DESCRIPTION
**What's this do?**
This PR adds a verification to see if the current task's file name that is are being downloaded in the full downloading sequence is the same whenever a chapter downloading is finished. For instance, if an audiobook is being downloaded and it's on a task whose file name is "ABC", if the user presses on a task with the file name "DEF", as soon as the user's selected chapter completes the download, it won't trigger the sequence's next task because the file names do not match.
This PR also fixes a UI issue where the TOC chapters' UI weren't being updated except for the first one.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-There-is-a-chaotical-downloading-of-tracks-in-TOC-after-tapping-several-times-the-circular--dd37637de78e406cb33914717800a3d4) that says the audiobook's chapter downloading becomes chaotical after pressing on some chapter

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select LYRASIS Reads
Open any audiobook except from the Bibliotheca lane
Open the book's TOC
Verify the chapter downloading is happening sequentially
Press a chapter from the list
Verify both chapters (the one you pressed and the one from the sequece) are downloaded without any issues and all the chapters' UI is being updated

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 