### PR TITLE
Fixed some issues while dragging the player's seekbar

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-21T15:38:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-07-25T13:16:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -187,7 +187,8 @@
         <c:change date="2022-07-18T00:00:00+00:00" summary="Disabled click on audiobook seekbar."/>
         <c:change date="2022-07-19T00:00:00+00:00" summary="Updated audiobook playback rate with saved value."/>
         <c:change date="2022-07-20T00:00:00+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
-        <c:change date="2022-07-21T15:38:15+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
+        <c:change date="2022-07-21T00:00:00+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
+        <c:change date="2022-07-25T13:16:28+00:00" summary="Fixed some issues while dragging the player's seekbar."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -114,6 +114,7 @@ class PlayerFragment : Fragment() {
   private lateinit var sleepTimer: PlayerSleepTimerType
   private lateinit var timeStrings: PlayerTimeStrings.SpokenTranslations
   private lateinit var toolbar: Toolbar
+  private var clickedOnThumb: Boolean = false
   private var playerBufferingStillOngoing: Boolean = false
   private var playerBufferingTask: ScheduledFuture<*>? = null
   private var playerPositionDragging: Boolean = false
@@ -498,32 +499,32 @@ class PlayerFragment : Fragment() {
   private fun handleTouchOnSeekbar(event: MotionEvent?): Boolean {
     when (event?.action) {
       MotionEvent.ACTION_DOWN -> {
-        return if (wasSeekbarThumbClicked(event)) {
-          playerPositionDragging = true
-          playerPosition.onTouchEvent(event)
-        } else {
-          true
-        }
-      }
-      MotionEvent.ACTION_UP -> {
-        val wasDragging = playerPositionDragging
-        playerPositionDragging = false
-        return if (wasSeekbarThumbClicked(event)) {
-          if (wasDragging) {
-            onProgressBarDraggingStopped()
-          }
-          playerPosition.onTouchEvent(event)
-        } else {
-          true
-        }
-      }
-      MotionEvent.ACTION_MOVE -> {
-        if (!playerPositionDragging) {
+        clickedOnThumb = wasSeekbarThumbClicked(event)
+        if (!clickedOnThumb) {
           return true
         }
       }
-      MotionEvent.ACTION_CANCEL ->
+      MotionEvent.ACTION_UP -> {
+        if (clickedOnThumb && playerPositionDragging) {
+          playerPositionDragging = false
+          clickedOnThumb = false
+          onProgressBarDraggingStopped()
+        } else {
+          playerPositionDragging = false
+          clickedOnThumb = false
+          return true
+        }
+      }
+      MotionEvent.ACTION_MOVE -> {
+        if (!clickedOnThumb) {
+          return true
+        }
+        playerPositionDragging = true
+      }
+      MotionEvent.ACTION_CANCEL -> {
         playerPositionDragging = false
+        clickedOnThumb = false
+      }
     }
 
     return playerPosition.onTouchEvent(event)


### PR DESCRIPTION
**What's this do?**
This PR updates the logic of movement actions (up, down, move, etc.) on the seekbar.

**Why are we doing this? (w/ JIRA link if applicable)**
A bug has been found and reported in [this card's "Updates" section](https://www.notion.so/lyrasis/Android-Audiobooks-need-to-change-player-to-require-dragging-time-bar-to-skip-forward-or-back-in-tr-eb232027287d476eb3c144436b9adfba) regarding some actions performed on the seekbar that was causing the app's UI to misbehave and the audiobook to be improperly played.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Perform some dragging and clicking events on the player's seekbar and verify the book's being played correctly

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 