### PR TITLE
Fixed audiobook bookmarks not being saved after exiting the player.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-25T13:16:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-08-03T09:58:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -188,8 +188,9 @@
         <c:change date="2022-07-19T00:00:00+00:00" summary="Updated audiobook playback rate with saved value."/>
         <c:change date="2022-07-20T00:00:00+00:00" summary="Fixed audiobook not playing from correct position after dragging seekbar"/>
         <c:change date="2022-07-21T00:00:00+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
-        <c:change date="2022-07-23T11:35:01+00:00" summary="Fixed chaotical chapter downloading after clicking on a specific chapter to download"/>
-        <c:change date="2022-07-25T13:16:28+00:00" summary="Fixed some issues while dragging the player's seekbar."/>
+        <c:change date="2022-07-23T00:00:00+00:00" summary="Fixed chaotical chapter downloading after clicking on a specific chapter to download"/>
+        <c:change date="2022-07-25T00:00:00+00:00" summary="Fixed some issues while dragging the player's seekbar."/>
+        <c:change date="2022-08-03T09:58:52+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerEvent.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerEvent.kt
@@ -123,7 +123,8 @@ sealed class PlayerEvent {
 
     data class PlayerEventCreateBookmark(
       override val spineElement: PlayerSpineElementType,
-      val offsetMilliseconds: Long
+      val offsetMilliseconds: Long,
+      val isLocalBookmark: Boolean
     ) : PlayerEventWithSpineElement()
   }
 }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -85,9 +85,13 @@ class ExoBookmarkObserver private constructor(
       true
     }
 
+    this.onBookmarkCreate(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
+      isLocalBookmark = true))
+
     if (create) {
       this.timeAtLast = timeNow
-      this.onBookmarkCreate(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds))
+      this.onBookmarkCreate(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
+        isLocalBookmark = false))
     }
   }
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -150,8 +150,6 @@ class PlayerFragment : Fragment() {
         as PlayerFragmentParameters
     this.timeStrings =
       PlayerTimeStrings.SpokenTranslations.createFromResources(this.resources)
-
-    this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
   }
 
   override fun onAttach(context: Context) {
@@ -493,6 +491,8 @@ class PlayerFragment : Fragment() {
     this.playerTitleView.text = this.listener.onPlayerWantsTitle()
     this.playerAuthorView.text = this.listener.onPlayerWantsAuthor()
 
+    this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
+
     initializeService()
   }
 
@@ -586,15 +586,19 @@ class PlayerFragment : Fragment() {
       PlayerEventManifestUpdated ->
         this.onPlayerEventManifestUpdated()
       is PlayerEventCreateBookmark ->
-        this.onPlayerEventCreateBookmark()
+        this.onPlayerEventCreateBookmark(event)
     }
   }
 
   /*
-   * Show a small icon to demonstrate that a bookmark was created.
+   * Show a small icon to demonstrate that a remote bookmark was created.
    */
 
-  private fun onPlayerEventCreateBookmark() {
+  private fun onPlayerEventCreateBookmark(event: PlayerEventCreateBookmark) {
+    if (event.isLocalBookmark) {
+      return
+    }
+
     UIThread.runOnUIThread {
       safelyPerformOperations {
         this.playerBookmark.alpha = 0.5f


### PR DESCRIPTION
**What's this do?**
This PR changes the way we're saving the audiobook bookmarks. Instead of creating a bookmark for every 5 seconds, we are now creating a local bookmark every second and a remote bookmark every 5 seconds. This way, we can remotely save the last local bookmark after leaving the player's screen (implemented on [this PR](https://github.com/ThePalaceProject/android-core/pull/130)). This PR also fixes a small bug regarding the bookmark not being correctly restored on some audiobooks when opening them

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a ticket with a bug](https://www.notion.so/lyrasis/Android-Last-reading-position-is-not-saved-after-reopening-the-audiobook-from-Biblioboard-or-Palac-b1ea2ca76af54449aa05b22f5d598f88) saying that some audiobooks are not storing the last position after exiting the player screen.

**How should this be tested? / Do these changes have associated tests?**
The main feature of this PR can only be tested when [this PR](https://github.com/ThePalaceProject/android-core/pull/130) is merged, but it's possible to test the UI issue regarding the player rate:

Open the Palace app
Select "LYRASIS Reads"
Open the "Daykeeper" audiobook
Listen to the audiobook for some seconds
Return to the previous screen and back to the audiobook
Verify the UI is displaying the bookmark's related information (chapter, offset, etc.)

**Dependencies for merging? Releasing to production?**
This PR depends on [this PR](https://github.com/ThePalaceProject/android-core/pull/130)

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 