### PR TITLE
Change chapter duration on audiobook player

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -175,7 +175,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed Feedbooks manifests not being accepted by the open access engine."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-03T09:58:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2022-08-10T19:04:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2022-05-02T00:00:00+00:00" summary="Fixed audiobook chapters/tracks downloading logic to prevent the download of repeated files"/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added support for bearer token downloads of manifests and audio files."/>
@@ -190,7 +190,8 @@
         <c:change date="2022-07-21T00:00:00+00:00" summary="Fixed empty gap instead of cancel button on sleep timer and playback rate dialogs"/>
         <c:change date="2022-07-23T00:00:00+00:00" summary="Fixed chaotical chapter downloading after clicking on a specific chapter to download"/>
         <c:change date="2022-07-25T00:00:00+00:00" summary="Fixed some issues while dragging the player's seekbar."/>
-        <c:change date="2022-08-03T09:58:52+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
+        <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
+        <c:change date="2022-08-10T19:04:44+00:00" summary="Change chapter duration on audiobook player."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -833,7 +833,8 @@ class PlayerFragment : Fragment() {
     }
 
     this.playerTimeMaximum.text =
-      PlayerTimeStrings.hourMinuteSecondTextFromDurationOptional(spineElement.duration)
+      PlayerTimeStrings.hourMinuteSecondTextFromDurationOptional(spineElement.duration
+        ?.minus(offsetMilliseconds))
     this.playerTimeMaximum.contentDescription =
       this.playerTimeRemainingSpokenOptional(offsetMilliseconds, spineElement.duration)
 


### PR DESCRIPTION
**What's this do?**
This PR subtracts the current chapter offset from the chapter duration in order to make the chapter duration label update everytime the player seekbar changes.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-The-chapter-time-doesn-t-change-during-playback-of-audiobooks-e3999d01538c428590193cf7b47d2508) to update the chapter missing duration in order to make the app similar to the iOS version.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Verify the chapter duration label is update everytime the seekbar changes

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 