### PR TITLE
Added audiobook's remaining time label to player.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -193,9 +193,10 @@
         <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-14T01:13:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.1">
+    <c:release date="2022-08-26T10:07:19+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.1">
       <c:changes>
-        <c:change date="2022-08-10T19:04:44+00:00" summary="Change chapter duration on audiobook player."/>
+        <c:change date="2022-08-10T00:00:00+00:00" summary="Change chapter duration on audiobook player."/>
+        <c:change date="2022-08-26T10:07:19+00:00" summary="Added audiobook's remaining time label to player."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -103,6 +103,7 @@ class PlayerFragment : Fragment() {
   private lateinit var playerDownloadingChapter: ProgressBar
   private lateinit var playerInfoModel: PlayerInfoModel
   private lateinit var playerPosition: SeekBar
+  private lateinit var playerRemainingChapterTime: TextView
   private lateinit var playerService: PlayerService
   private lateinit var playerSkipBackwardButton: ImageView
   private lateinit var playerSkipForwardButton: ImageView
@@ -484,6 +485,7 @@ class PlayerFragment : Fragment() {
 
     this.playerTimeCurrent = view.findViewById(R.id.player_time)!!
     this.playerTimeMaximum = view.findViewById(R.id.player_time_maximum)!!
+    this.playerRemainingChapterTime = view.findViewById(R.id.player_remaining_chapter_time)!!
     this.playerSpineElement = view.findViewById(R.id.player_spine_element)!!
     this.playerSpineElement.text = this.spineElementText(this.book.spine.first())
 
@@ -832,6 +834,12 @@ class PlayerFragment : Fragment() {
         TimeUnit.MILLISECONDS.toSeconds(offsetMilliseconds).toInt()
     }
 
+    playerRemainingChapterTime.text =
+      PlayerTimeStrings.hourMinuteTextFromRemainingTime(
+        requireContext(),
+        getCurrentAudiobookRemainingDuration(spineElement) - offsetMilliseconds
+    )
+
     this.playerTimeMaximum.text =
       PlayerTimeStrings.hourMinuteSecondTextFromDurationOptional(spineElement.duration
         ?.minus(offsetMilliseconds))
@@ -861,6 +869,17 @@ class PlayerFragment : Fragment() {
       R.string.audiobook_accessibility_player_time_current,
       PlayerTimeStrings.hourMinuteSecondSpokenFromMilliseconds(this.timeStrings, offsetMilliseconds)
     )
+  }
+
+  private fun getCurrentAudiobookRemainingDuration(spineElement: PlayerSpineElementType): Long {
+    val totalDuration = book.spine.sumOf { it.duration?.millis ?: 0L }
+    val totalTimeElapsed = if (spineElement.index == 0) {
+      0L
+    } else {
+      book.spine.subList(0, spineElement.index).sumOf { it.duration?.millis ?: 0L }
+    }
+
+    return totalDuration - totalTimeElapsed
   }
 
   private fun playerTimeRemainingSpoken(

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -103,7 +103,7 @@ class PlayerFragment : Fragment() {
   private lateinit var playerDownloadingChapter: ProgressBar
   private lateinit var playerInfoModel: PlayerInfoModel
   private lateinit var playerPosition: SeekBar
-  private lateinit var playerRemainingChapterTime: TextView
+  private lateinit var playerRemainingBookTime: TextView
   private lateinit var playerService: PlayerService
   private lateinit var playerSkipBackwardButton: ImageView
   private lateinit var playerSkipForwardButton: ImageView
@@ -485,7 +485,7 @@ class PlayerFragment : Fragment() {
 
     this.playerTimeCurrent = view.findViewById(R.id.player_time)!!
     this.playerTimeMaximum = view.findViewById(R.id.player_time_maximum)!!
-    this.playerRemainingChapterTime = view.findViewById(R.id.player_remaining_chapter_time)!!
+    this.playerRemainingBookTime = view.findViewById(R.id.player_remaining_book_time)!!
     this.playerSpineElement = view.findViewById(R.id.player_spine_element)!!
     this.playerSpineElement.text = this.spineElementText(this.book.spine.first())
 
@@ -834,7 +834,7 @@ class PlayerFragment : Fragment() {
         TimeUnit.MILLISECONDS.toSeconds(offsetMilliseconds).toInt()
     }
 
-    playerRemainingChapterTime.text =
+    playerRemainingBookTime.text =
       PlayerTimeStrings.hourMinuteTextFromRemainingTime(
         requireContext(),
         getCurrentAudiobookRemainingDuration(spineElement) - offsetMilliseconds

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.views
 
+import android.content.Context
 import android.content.res.Resources
 import org.joda.time.Duration
 import org.joda.time.Period
@@ -75,6 +76,15 @@ object PlayerTimeStrings {
     }
   }
 
+  private val hourMinuteFormatter: PeriodFormatter =
+    PeriodFormatterBuilder()
+      .minimumPrintedDigits(2)
+      .appendHours()
+      .appendLiteral(" hr ")
+      .appendMinutes()
+      .appendLiteral(" min remaining")
+      .toFormatter()
+
   private val hourMinuteSecondFormatter: PeriodFormatter =
     PeriodFormatterBuilder()
       .printZeroAlways()
@@ -107,7 +117,19 @@ object PlayerTimeStrings {
   }
 
   fun hourMinuteSecondTextFromDurationOptional(duration: Duration?): String {
-    return duration?.let { time -> hourMinuteSecondTextFromDuration(time) } ?: ""
+    return duration?.let { time -> hourMinuteSecondTextFromDuration(time) }.orEmpty()
+  }
+
+  fun hourMinuteTextFromRemainingTime(context: Context, remainingTime: Long): String {
+
+    val minutes = (remainingTime / 60000).toInt()
+    val hours = minutes / 60
+
+    return if (hours == 0) {
+      context.getString(R.string.audiobook_player_remaining_time_minutes_only, minutes)
+    } else {
+      context.getString(R.string.audiobook_player_remaining_time, hours, minutes)
+    }
   }
 
   fun hourMinuteSecondTextFromDuration(duration: Duration): String {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
@@ -113,7 +113,7 @@ object PlayerTimeStrings {
 
   fun hourMinuteTextFromRemainingTime(context: Context, remainingTime: Long): String {
 
-    val minutes = ((remainingTime / (60 * 1000)) % 60).toInt()
+    val minutes = ((remainingTime / (1000 * 60)) % 60).toInt()
     val hours = ((remainingTime / (1000 * 60 * 60)) % 24).toInt()
 
     return if (hours == 0) {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
@@ -76,15 +76,6 @@ object PlayerTimeStrings {
     }
   }
 
-  private val hourMinuteFormatter: PeriodFormatter =
-    PeriodFormatterBuilder()
-      .minimumPrintedDigits(2)
-      .appendHours()
-      .appendLiteral(" hr ")
-      .appendMinutes()
-      .appendLiteral(" min remaining")
-      .toFormatter()
-
   private val hourMinuteSecondFormatter: PeriodFormatter =
     PeriodFormatterBuilder()
       .printZeroAlways()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
@@ -122,8 +122,8 @@ object PlayerTimeStrings {
 
   fun hourMinuteTextFromRemainingTime(context: Context, remainingTime: Long): String {
 
-    val minutes = (remainingTime / 60000).toInt()
-    val hours = minutes / 60
+    val minutes = ((remainingTime / (60 * 1000)) % 60).toInt()
+    val hours = ((remainingTime / (1000 * 60 * 60)) % 24).toInt()
 
     return if (hours == 0) {
       context.getString(R.string.audiobook_player_remaining_time_minutes_only, minutes)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTimeStrings.kt
@@ -114,7 +114,7 @@ object PlayerTimeStrings {
   fun hourMinuteTextFromRemainingTime(context: Context, remainingTime: Long): String {
 
     val minutes = ((remainingTime / (1000 * 60)) % 60).toInt()
-    val hours = ((remainingTime / (1000 * 60 * 60)) % 24).toInt()
+    val hours = (remainingTime / (1000 * 60 * 60)).toInt()
 
     return if (hours == 0) {
       context.getString(R.string.audiobook_player_remaining_time_minutes_only, minutes)

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -30,7 +30,7 @@
         android:ellipsize="end"
         android:gravity="center"
         android:lines="1"
-        android:textSize="24sp"
+        android:textSize="22sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -47,11 +47,24 @@
         android:ellipsize="end"
         android:gravity="center"
         android:lines="1"
-        android:textSize="18sp"
+        android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/player_title"
         tools:text="Very, very, very long placeholder text that should never be seen in practice." />
+
+    <TextView
+        android:id="@+id/player_remaining_chapter_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:lines="1"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_author"
+        tools:text="4 hr 56 min remaining" />
 
     <SeekBar
         android:id="@+id/player_progress"
@@ -65,7 +78,7 @@
         android:scaleY="2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_author" />
+        app:layout_constraintTop_toBottomOf="@id/player_remaining_chapter_time" />
 
     <TextView
         android:id="@+id/player_time"

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -54,7 +54,7 @@
         tools:text="Very, very, very long placeholder text that should never be seen in practice." />
 
     <TextView
-        android:id="@+id/player_remaining_chapter_time"
+        android:id="@+id/player_remaining_book_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -78,7 +78,7 @@
         android:scaleY="2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/player_remaining_chapter_time" />
+        app:layout_constraintTop_toBottomOf="@id/player_remaining_book_time" />
 
     <TextView
         android:id="@+id/player_time"

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
   <string name="audiobook_player_play">Play</string>
   <string name="audiobook_player_pause">Pause</string>
 
+  <string name="audiobook_player_remaining_time">%1$d hr %2$d min remaining</string>
+  <string name="audiobook_player_remaining_time_minutes_only">%d min remaining</string>
+
   <string name="audiobook_part_delete_confirm">Delete this book part?</string>
   <string name="audiobook_part_delete">Delete</string>
   <string name="audiobook_part_delete_keep">Keep</string>


### PR DESCRIPTION
**What's this do?**
This PR adds logic to calculate the remaining time for the audiobook to be completed and updates the player's UI by adding the label with the remaining time and by making a few adjustments to the existing elements.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Add-the-line-for-time-remaining-in-audiobooks-37e87b44c4b0410f88add25b1f9186e2) to include this label in order to make the app similar to the iOS version.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Verify [there's a label with the books remaining time](https://user-images.githubusercontent.com/79104027/186894639-b7d30feb-c62c-449b-bad9-4d018c9a90ce.png)
Drag the seekbar for a minute or change the chapter
Verify [the label was updated](https://user-images.githubusercontent.com/79104027/186894648-6abc4aa9-d83a-4fa9-a775-4e6a3937318f.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 