### PR TITLE
Fixed crash on MediaButton receiver

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -193,10 +193,11 @@
         <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-26T10:07:19+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.1">
+    <c:release date="2022-09-07T12:00:32+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.1">
       <c:changes>
         <c:change date="2022-08-10T00:00:00+00:00" summary="Change chapter duration on audiobook player."/>
-        <c:change date="2022-08-26T10:07:19+00:00" summary="Added audiobook's remaining time label to player."/>
+        <c:change date="2022-08-26T00:00:00+00:00" summary="Added audiobook's remaining time label to player."/>
+        <c:change date="2022-09-07T12:00:32+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
+++ b/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
             android:exported="false" />
 
         <receiver
-            android:name="androidx.media.session.MediaButtonReceiver"
+            android:name=".PlayerMediaButtonReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerMediaButtonReceiver.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerMediaButtonReceiver.kt
@@ -1,0 +1,19 @@
+package org.librarysimplified.audiobook.views
+
+import android.content.Context
+import android.content.Intent
+import androidx.media.session.MediaButtonReceiver
+import org.slf4j.LoggerFactory
+
+class PlayerMediaButtonReceiver : MediaButtonReceiver() {
+
+  private val logger = LoggerFactory.getLogger(PlayerMediaButtonReceiver::class.java)
+
+  override fun onReceive(context: Context?, intent: Intent?) {
+    try {
+      super.onReceive(context, intent)
+    } catch (exception: IllegalStateException) {
+      this.logger.error("Received exception on MediaButtonReceiver: {}", exception)
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
This PR creates a custom MediaButton receiver that will allow the app to catch the IllegalStateException that is thrown when the device can't handle the _MEDIA_BUTTON_ service.

**Why are we doing this? (w/ JIRA link if applicable)**
There's been a significant number of crashes happening on devices that couldn't support the _MEDIA_BUTTON_ service

**How should this be tested? / Do these changes have associated tests?**
Open the app
Open any audiobook
Drag down the status bar and verify that the notification with the player commands is there
Confirm everything is still working fine (play, pause, etc.)

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 