### PR TITLE
Added management of different audio sources

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,8 +200,10 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-19T02:13:27+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
-      <c:changes/>
+    <c:release date="2022-09-26T09:55:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+      <c:changes>
+        <c:change date="2022-09-26T09:55:24+00:00" summary="Added management of audio coming from different apps."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=8.0.2-SNAPSHOT
-VERSION_PREVIOUS=8.0.0
+VERSION_PREVIOUS=7.0.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=8.0.2-SNAPSHOT
-VERSION_PREVIOUS=8.0.1
+VERSION_PREVIOUS=8.0.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -786,7 +786,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
       .build()
 
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       audioRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setAudioAttributes(playbackAttributes)
         .setWillPauseWhenDucked(true)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -783,12 +783,13 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     // initiate the audio playback attributes
     val playbackAttributes = AudioAttributes.Builder()
       .setUsage(AudioAttributes.USAGE_MEDIA)
-      .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+      .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
       .build()
 
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       audioRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setAudioAttributes(playbackAttributes)
+        .setWillPauseWhenDucked(true)
         .setAcceptsDelayedFocusGain(true)
         .setOnAudioFocusChangeListener(this)
         .build()


### PR DESCRIPTION
**What's this do?**
This PR adds logic to manage the audio coming from different audio sources. By request the audio focus to the player, we'll know when another app requests the audio focus and then we can handle that event in the way we want to.

**Why are we doing this? (w/ JIRA link if applicable)**
There are some reported tickets ([here](https://www.notion.so/lyrasis/Pause-audiobook-when-audio-from-GPS-is-playing-507ab627382e483bb3a8f515f21bed99), [here](https://www.notion.so/lyrasis/Android-The-audiobooks-from-Biblioboard-Palace-Marketplace-and-Overdrive-distributors-don-t-pause--5b9a707adf3941399c961787485be8fb) and [here](https://www.notion.so/lyrasis/Android-Make-the-playback-of-audiobooks-while-running-other-applications-the-same-with-iOS-a5db9e5ab85d463ba46fedcfd15a24c8)) saying that there have been some bad UX when an audiobook is being played and then some other audio source starts playing.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook and start playing it
Open a video from Youtube
Verify the audiobook has stopped playing
Close the video and resume the audiobook
Go to a navigation app and start navigating to somewhere
Verify the audiobook volume is automatically decreased whenever the navigation assistant starts talking and automatically increased when the assistant stops
Stop the navigation
Using another phone device, make a call to the device where the audiobook is being played
Verify the audioobok automatically pauses and when the call is over it's automatically resumed

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 