### PR TITLE
Added content description to back button on player screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,8 +200,10 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-19T02:13:27+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
-      <c:changes/>
+    <c:release date="2022-09-27T23:03:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+      <c:changes>
+        <c:change date="2022-09-27T23:03:05+00:00" summary="Added content description to back button on player screen."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=8.0.2-SNAPSHOT
-VERSION_PREVIOUS=8.0.1
+VERSION_PREVIOUS=7.0.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -452,6 +452,7 @@ class PlayerFragment : Fragment() {
     super.onViewCreated(view, state)
 
     this.toolbar = view.findViewById(R.id.audioBookToolbar)
+    this.toolbar.setNavigationContentDescription(R.string.audiobook_accessibility_navigation_back)
     configureToolbarActions()
 
     this.coverView = view.findViewById(R.id.player_cover)!!

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
   <string name="audiobook_accessibility_minute">Minute</string>
   <string name="audiobook_accessibility_second">Second</string>
 
+  <string name="audiobook_accessibility_navigation_back">Back</string>
+
   <string name="audiobook_accessibility_player_buffering">Player Is Buffering</string>
 
   <string name="audiobook_accessibility_player_time_current">%1$s Played</string>


### PR DESCRIPTION
**What's this do?**
This PR adds a content description to the back button on the toolbar of the player screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-There-are-unlabeled-buttons-on-the-book-reading-and-listening-screens-1847df33398945e487c8f0e6b3a136df) saying that the back button of the player's toolbar doesn't display a "Text" value when selecting on the inspect mode of the BrowserStack.

**How should this be tested? / Do these changes have associated tests?**
The [BrowserStack now displays the "Back" label](https://user-images.githubusercontent.com/79104027/192653077-2800ce3d-4a66-4578-8c42-30366fff26fc.png) on the Inspect Mode, but this can be tested by:

1. Turn the TalkBack feature of the phone in the Accessibility options
2. Open the Palace app
3. Open any audiobook to start listening to it
4. Click on the "Back" button.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 