### PR TITLE
Fixed audiobook chapter's time elapsed and remaining and book remaini…

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,10 +200,11 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-27T23:03:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-09-29T10:39:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
-        <c:change date="2022-09-27T23:03:05+00:00" summary="Added content description to back button on player screen."/>
-        <c:change date="2022-09-26T09:55:24+00:00" summary="Added management of audio coming from different apps."/>
+        <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
+        <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
+        <c:change date="2022-09-29T10:39:14+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -522,7 +522,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
         if (clickedOnThumb && playerPositionDragging) {
           playerPositionDragging = false
           clickedOnThumb = false
-          onProgressBarDraggingStopped()
+          updateUIOnProgressBarDragging()
         } else {
           playerPositionDragging = false
           clickedOnThumb = false
@@ -534,6 +534,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
           return true
         }
         playerPositionDragging = true
+        updateUIOnProgressBarDragging()
       }
       MotionEvent.ACTION_CANCEL -> {
         playerPositionDragging = false
@@ -544,8 +545,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     return playerPosition.onTouchEvent(event)
   }
 
-  private fun onProgressBarDraggingStopped() {
-    this.log.debug("onProgressBarDraggingStopped")
+  private fun updateUIOnProgressBarDragging() {
+    this.log.debug("updateUIOnProgressBarDragging")
 
     val spine = this.playerPositionCurrentSpine
     if (spine != null) {


### PR DESCRIPTION
**What's this do?**
This PR adds a call to the method that updates the UI when the user is dragging the seekbar instead of just calling it after the user stops dragging the seekbar.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug saying that the UI is not updating](https://www.notion.so/lyrasis/Android-Audiobooks-Make-the-overall-time-remaining-of-the-book-the-listened-time-and-the-remainin-2edd31bb916346f4bbb59bf29d0f5d53) when dragging the seekbar and that it should be updating to make it similar to the iOS app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Drag the seekbar
Verify the [chapter elapsed time, the chapter remaining time and the book remaining time are updating](https://user-images.githubusercontent.com/79104027/193011281-0d226227-b2cf-46cf-92cb-f5373ce6bc1f.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 