### PR TITLE
Updated TOC's UI

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,10 +200,11 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-27T23:03:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-10-03T10:48:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
-        <c:change date="2022-09-27T23:03:05+00:00" summary="Added content description to back button on player screen."/>
-        <c:change date="2022-09-26T09:55:24+00:00" summary="Added management of audio coming from different apps."/>
+        <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
+        <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
+        <c:change date="2022-10-03T10:48:46+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -98,6 +98,12 @@ class PlayerTOCAdapter(
     var failedDownload = false
     var downloading = false
     val status = item.downloadStatus
+    holder.buttons.visibility = if (status !is PlayerSpineElementDownloaded) {
+      VISIBLE
+    } else {
+      GONE
+    }
+
     when (status) {
       is PlayerSpineElementNotDownloaded -> {
         holder.buttonsDownloading.visibility = INVISIBLE
@@ -171,11 +177,6 @@ class PlayerTOCAdapter(
       }
 
       is PlayerSpineElementDownloaded -> {
-        holder.buttonsDownloading.visibility = GONE
-        holder.buttonsDownloadFailed.visibility = GONE
-        holder.buttonsNotDownloadedStreamable.visibility = GONE
-        holder.buttonsNotDownloadedNotStreamable.visibility = GONE
-
         holder.view.isEnabled = true
       }
 
@@ -311,7 +312,7 @@ class PlayerTOCAdapter(
 
   inner class ViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
 
-    private val buttons: ViewGroup =
+    val buttons: ViewGroup =
       this.view.findViewById(R.id.player_toc_end_controls)
     val buttonsDownloadFailed: ViewGroup =
       this.buttons.findViewById(R.id.player_toc_item_buttons_error)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -6,6 +6,7 @@ import android.content.DialogInterface
 import android.content.res.Resources
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.GONE
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
@@ -87,7 +88,10 @@ class PlayerTOCAdapter(
 
     holder.titleText.text = title
     holder.titleText.isEnabled = false
-
+    holder.downloadedDurationText.text =
+      item.duration?.let {
+        this.periodFormatter.print(it.toPeriod())
+      } ?: ""
     holder.view.isEnabled = item.book.supportsStreaming
 
     var requiresDownload = false
@@ -96,7 +100,6 @@ class PlayerTOCAdapter(
     val status = item.downloadStatus
     when (status) {
       is PlayerSpineElementNotDownloaded -> {
-        holder.buttonsDownloaded.visibility = INVISIBLE
         holder.buttonsDownloading.visibility = INVISIBLE
         holder.buttonsDownloadFailed.visibility = INVISIBLE
 
@@ -146,7 +149,6 @@ class PlayerTOCAdapter(
       }
 
       is PlayerSpineElementDownloading -> {
-        holder.buttonsDownloaded.visibility = INVISIBLE
         holder.buttonsDownloading.visibility = VISIBLE
         holder.buttonsDownloadFailed.visibility = INVISIBLE
         holder.buttonsNotDownloadedStreamable.visibility = INVISIBLE
@@ -169,22 +171,15 @@ class PlayerTOCAdapter(
       }
 
       is PlayerSpineElementDownloaded -> {
-        holder.buttonsDownloaded.visibility = VISIBLE
-        holder.buttonsDownloading.visibility = INVISIBLE
-        holder.buttonsDownloadFailed.visibility = INVISIBLE
-        holder.buttonsNotDownloadedStreamable.visibility = INVISIBLE
-        holder.buttonsNotDownloadedNotStreamable.visibility = INVISIBLE
+        holder.buttonsDownloading.visibility = GONE
+        holder.buttonsDownloadFailed.visibility = GONE
+        holder.buttonsNotDownloadedStreamable.visibility = GONE
+        holder.buttonsNotDownloadedNotStreamable.visibility = GONE
 
         holder.view.isEnabled = true
-
-        holder.downloadedDurationText.text =
-          item.duration?.let {
-            this.periodFormatter.print(it.toPeriod())
-          } ?: ""
       }
 
       is PlayerSpineElementDownloadFailed -> {
-        holder.buttonsDownloaded.visibility = INVISIBLE
         holder.buttonsDownloading.visibility = INVISIBLE
         holder.buttonsDownloadFailed.visibility = VISIBLE
         holder.buttonsNotDownloadedStreamable.visibility = INVISIBLE
@@ -316,18 +311,16 @@ class PlayerTOCAdapter(
 
   inner class ViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
 
-    val buttons =
-      this.view.findViewById<ViewGroup>(R.id.player_toc_end_controls)
-    val buttonsDownloadFailed =
-      this.buttons.findViewById<ViewGroup>(R.id.player_toc_item_buttons_error)
-    val buttonsDownloaded =
-      this.buttons.findViewById<ViewGroup>(R.id.player_toc_item_buttons_downloaded)
-    val buttonsNotDownloadedNotStreamable =
-      this.buttons.findViewById<ViewGroup>(R.id.player_toc_item_buttons_not_downloaded_not_streamable)
-    val buttonsNotDownloadedStreamable =
-      this.buttons.findViewById<ViewGroup>(R.id.player_toc_item_buttons_not_downloaded_streamable)
-    val buttonsDownloading =
-      this.buttons.findViewById<ViewGroup>(R.id.player_toc_item_buttons_downloading)
+    private val buttons: ViewGroup =
+      this.view.findViewById(R.id.player_toc_end_controls)
+    val buttonsDownloadFailed: ViewGroup =
+      this.buttons.findViewById(R.id.player_toc_item_buttons_error)
+    val buttonsNotDownloadedNotStreamable: ViewGroup =
+      this.buttons.findViewById(R.id.player_toc_item_buttons_not_downloaded_not_streamable)
+    val buttonsNotDownloadedStreamable: ViewGroup =
+      this.buttons.findViewById(R.id.player_toc_item_buttons_not_downloaded_streamable)
+    val buttonsDownloading: ViewGroup =
+      this.buttons.findViewById(R.id.player_toc_item_buttons_downloading)
 
     val titleText: TextView =
       this.view.findViewById(R.id.player_toc_item_view_title)
@@ -340,7 +333,7 @@ class PlayerTOCAdapter(
       this.buttonsDownloadFailed.findViewById(R.id.player_toc_item_download_failed_refresh)
 
     val downloadedDurationText: TextView =
-      this.buttonsDownloaded.findViewById(R.id.player_toc_item_downloaded_duration)
+      this.view.findViewById(R.id.player_toc_item_duration)
 
     val notDownloadedStreamableRefresh: ImageView =
       this.buttonsNotDownloadedStreamable.findViewById(

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_item_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_item_view.xml
@@ -1,65 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-  android:layout_height="80dp">
+    android:layout_height="80dp"
+    android:orientation="horizontal">
 
   <ImageView
-    android:id="@+id/player_toc_item_is_current"
-    android:layout_width="16dp"
-    android:layout_height="16dp"
-    android:layout_centerVertical="true"
-    android:layout_marginLeft="16dp"
-    android:focusable="false"
-    android:clickable="false"
-    android:importantForAccessibility="no"
-    android:src="@drawable/circle"
-    app:tint="?attr/simplifiedColorControlList" />
-
-  <FrameLayout
-    android:id="@+id/player_toc_end_controls"
-    android:layout_marginRight="16dp"
-    android:layout_alignParentRight="true"
-    android:layout_width="80dp"
-    android:layout_height="80dp">
-    <include
-      android:id="@+id/player_toc_item_buttons_error"
-      layout="@layout/player_toc_item_buttons_download_failed"
-      android:visibility="gone" />
-    <include
-      android:id="@+id/player_toc_item_buttons_downloaded"
-      layout="@layout/player_toc_item_buttons_downloaded"
-      android:visibility="gone" />
-    <include
-      android:id="@+id/player_toc_item_buttons_not_downloaded_not_streamable"
-      layout="@layout/player_toc_item_buttons_not_downloaded_not_streamable"
-      android:visibility="gone" />
-    <include
-      android:id="@+id/player_toc_item_buttons_not_downloaded_streamable"
-      layout="@layout/player_toc_item_buttons_not_downloaded_streamable"
-      android:visibility="gone" />
-    <include
-      android:id="@+id/player_toc_item_buttons_downloading"
-      layout="@layout/player_toc_item_buttons_downloading"
-      android:visibility="gone" />
-  </FrameLayout>
+      android:id="@+id/player_toc_item_is_current"
+      android:layout_width="16dp"
+      android:layout_height="16dp"
+      android:layout_gravity="center_vertical"
+      android:layout_marginStart="16dp"
+      android:clickable="false"
+      android:focusable="false"
+      android:importantForAccessibility="no"
+      android:src="@drawable/circle"
+      app:tint="?attr/simplifiedColorControlList" />
 
   <TextView
-    android:id="@+id/player_toc_item_view_title"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerVertical="true"
-    android:layout_toLeftOf="@id/player_toc_end_controls"
-    android:layout_toRightOf="@+id/player_toc_item_is_current"
-    android:layout_marginLeft="16dp"
-    android:layout_marginRight="64dp"
-    android:clickable="false"
-    android:focusable="false"
-    android:importantForAccessibility="no"
-    android:lines="1"
-    android:ellipsize="end"
-    android:text="Very long placeholder text that should never be seen in practice."
-    android:textSize="18sp" />
+      android:id="@+id/player_toc_item_view_title"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:layout_marginStart="16dp"
+      android:layout_marginEnd="48dp"
+      android:layout_weight="1"
+      android:clickable="false"
+      android:ellipsize="end"
+      android:focusable="false"
+      android:importantForAccessibility="no"
+      android:lines="1"
+      android:textSize="18sp"
+      tools:text="Very long placeholder text that should never be seen in practice." />
 
-</RelativeLayout>
+  <TextView
+      android:id="@+id/player_toc_item_duration"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:layout_marginEnd="16dp"
+      android:clickable="false"
+      android:focusable="false"
+      android:importantForAccessibility="no"
+      android:text="00:00:00"
+      android:textSize="18sp"
+      android:visibility="visible"
+      app:tint="?attr/simplifiedColorControlList" />
+
+  <FrameLayout
+      android:id="@+id/player_toc_end_controls"
+      android:layout_width="wrap_content"
+      android:layout_height="80dp"
+      android:layout_marginEnd="16dp"
+      android:minWidth="80dp">
+
+    <include
+        android:id="@+id/player_toc_item_buttons_error"
+        layout="@layout/player_toc_item_buttons_download_failed"
+        android:visibility="gone" />
+
+    <include
+        android:id="@+id/player_toc_item_buttons_not_downloaded_not_streamable"
+        layout="@layout/player_toc_item_buttons_not_downloaded_not_streamable"
+        android:visibility="gone" />
+
+    <include
+        android:id="@+id/player_toc_item_buttons_not_downloaded_streamable"
+        layout="@layout/player_toc_item_buttons_not_downloaded_streamable"
+        android:visibility="gone" />
+
+    <include
+        android:id="@+id/player_toc_item_buttons_downloading"
+        layout="@layout/player_toc_item_buttons_downloading"
+        android:visibility="gone" />
+  </FrameLayout>
+
+</LinearLayout>


### PR DESCRIPTION
**What's this do?**
This PR updates the TOC screen UI by adding the item's duration regardless of its downloading status

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [reported bug](https://www.notion.so/lyrasis/Android-Overdrive-audiobooks-There-is-an-issue-with-time-displaying-on-listening-screen-and-in-TOC-2ead4cc9b2aa458c89d8338b84930a0c) that says the TOC items don't show their duration and just display a blank space. Even though this issue is related to an Overdrive audiobook's duration bug, the UI/UX can be improved by keeping the chapter's duration always there, like the iOS app does.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Click on the TOC icon
Confirm the [chapters duration are there even if they are not downloaded](https://user-images.githubusercontent.com/79104027/193561228-b59bd5e4-1eac-46f3-9a11-7a9225bd3577.png)

**Dependencies for merging? Releasing to production?**
It's not a dependency, but [this PR](https://github.com/ThePalaceProject/android-audiobook-overdrive/pull/3) is related to this feature.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 