### PR TITLE
Added audio focus request for Android 12+ versions

### DIFF
--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -788,9 +788,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
       .build()
 
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      AudioManager.AUDIOFOCUS_REQUEST_GRANTED
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       audioRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setAudioAttributes(playbackAttributes)
         .setWillPauseWhenDucked(true)


### PR DESCRIPTION
**What's this do?**
This PR adds the audio focus request for Android 12+ versions

**Why are we doing this? (w/ JIRA link if applicable)**
There [are some reports](https://www.notion.so/lyrasis/Android-The-audiobooks-from-Biblioboard-Palace-Marketplace-and-Overdrive-distributors-don-t-pause--5b9a707adf3941399c961787485be8fb) saying the audiobook was being muted instead of paused when there's an incoming call.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook and start playing it
Open a video from Youtube
Verify the audiobook has stopped playing
Close the video and resume the audiobook
Go to a navigation app and start navigating to somewhere
Verify the audiobook volume is automatically decreased whenever the navigation assistant starts talking and automatically increased when the assistant stops
Stop the navigation
Using another phone device, make a call to the device where the audiobook is being played
Verify the audioobok automatically pauses and when the call is over it's automatically resumed

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 