### PR TITLE
Target Android 12 (API 32).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,12 +200,13 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-03T10:48:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-10-20T05:08:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
         <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
         <c:change date="2022-09-29T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
-        <c:change date="2022-10-03T10:48:46+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
+        <c:change date="2022-10-03T00:00:00+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
+        <c:change date="2022-10-20T05:08:31+00:00" summary="Changed target version to Android 12."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-  if ("$gradle.gradleVersion" != "7.2") {
-    throw new GradleException("Gradle version 7.2 is required (received $gradle.gradleVersion)")
+  if ("$gradle.gradleVersion" != "7.4") {
+    throw new GradleException("Gradle version 7.4 is required (received $gradle.gradleVersion)")
   }
 
   // https://github.com/gradle/gradle/issues/11308#issuecomment-554317655
@@ -20,7 +20,7 @@ buildscript {
     classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
     classpath "digital.wup:android-maven-publish:3.6.3"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath "com.android.tools.build:gradle:7.0.2"
+    classpath 'com.android.tools.build:gradle:7.3.1'
     classpath "de.undercouch:gradle-download-task:4.1.2"
     classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.0.0"
   }
@@ -35,10 +35,10 @@ plugins {
 }
 
 ext {
-  androidBuildToolsVersion = "30.0.2"
-  androidCompileSDKVersion = 31
+  androidBuildToolsVersion = "32.0.0"
+  androidCompileSDKVersion = 32
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 28
+  androidTargetSDKVersion = 32
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")
@@ -76,6 +76,20 @@ allprojects { project ->
   version = project.ext["VERSION_NAME"]
 
   apply plugin: 'ca.cutterslade.analyze'
+
+  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
+  // fixed the issue.
+  project.configurations.all {
+    resolutionStrategy {
+      dependencySubstitution {
+        all { DependencySubstitution dependency ->
+          if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
+            dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
+          }
+        }
+      }
+    }
+  }
 }
 
 // Configure all projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Oct 19 12:24:46 EDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/org.librarysimplified.audiobook.views/build.gradle
+++ b/org.librarysimplified.audiobook.views/build.gradle
@@ -3,10 +3,10 @@ dependencies {
 
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout
+  implementation libs.androidx.media
   implementation libs.androidx.recycler.view
   implementation libs.kotlin.reflect
   implementation libs.kotlin.stdlib
   implementation libs.nypl.theme
   implementation libs.slf4j
-  implementation libs.androidx.legacy.support.v4
 }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -36,28 +36,44 @@ class PlayerService : Service() {
   private val backwardIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_BACKWARD),
-      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
     )
   }
 
   private val forwardIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_FORWARD),
-      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
     )
   }
 
   private val pauseIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_PAUSE),
-      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
     )
   }
 
   private val playIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_PLAY),
-      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
     )
   }
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -36,28 +36,28 @@ class PlayerService : Service() {
   private val backwardIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_BACKWARD),
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
   }
 
   private val forwardIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_FORWARD),
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
   }
 
   private val pauseIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_PAUSE),
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
   }
 
   private val playIntent by lazy {
     PendingIntent.getBroadcast(
       this, 0, Intent(ACTION_PLAY),
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
   }
 


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 12 (API 32), including necessary dependency and gradle upgrades.

Apps that target Android 12 must set FLAG_IMMUTABLE or FLAG_MUTABLE on PendingIntent objects, so this is done.

It also includes a workaround for the currently failing readium nanohttpd artifact downloads, which can be removed when that problem is fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Apps will be required to target Android 12 in November. Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

Different kinds of audiobooks should all play successfully, and the controls and table of contents should all work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested some audiobooks.