### PR TITLE
Target Android 13 (API 33).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,13 +200,14 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-20T05:08:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-10-27T15:31:42+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
         <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
         <c:change date="2022-09-29T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
         <c:change date="2022-10-03T00:00:00+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
-        <c:change date="2022-10-20T05:08:31+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-27T15:31:42+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ plugins {
 }
 
 ext {
-  androidBuildToolsVersion = "32.0.0"
-  androidCompileSDKVersion = 32
+  androidBuildToolsVersion = "33.0.0"
+  androidCompileSDKVersion = 33
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 32
+  androidTargetSDKVersion = 33
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")
@@ -76,20 +76,6 @@ allprojects { project ->
   version = project.ext["VERSION_NAME"]
 
   apply plugin: 'ca.cutterslade.analyze'
-
-  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
-  // fixed the issue.
-  project.configurations.all {
-    resolutionStrategy {
-      dependencySubstitution {
-        all { DependencySubstitution dependency ->
-          if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
-            dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
-          }
-        }
-      }
-    }
-  }
 }
 
 // Configure all projects

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -92,10 +92,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
   private lateinit var executor: ScheduledExecutorService
   private lateinit var listener: PlayerFragmentListenerType
   private lateinit var menuPlaybackRate: MenuItem
-  private lateinit var menuPlaybackRateText: TextView
   private lateinit var menuSleep: MenuItem
   private lateinit var menuSleepEndOfChapter: ImageView
-  private lateinit var menuSleepText: TextView
   private lateinit var menuTOC: MenuItem
   private lateinit var parameters: PlayerFragmentParameters
   private lateinit var playPauseButton: ImageView
@@ -118,6 +116,10 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
   private lateinit var sleepTimer: PlayerSleepTimerType
   private lateinit var timeStrings: PlayerTimeStrings.SpokenTranslations
   private lateinit var toolbar: Toolbar
+
+  private var menuPlaybackRateText: TextView? = null
+  private var menuSleepText: TextView? = null
+
   private var audioFocusDelayed: Boolean = false
   private var clickedOnThumb: Boolean = false
   private var playOnAudioFocus: Boolean = false
@@ -217,9 +219,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.menuSleepText.text = ""
-          this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
-          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepText?.text = ""
+          this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText?.visibility = INVISIBLE
           this.menuSleepEndOfChapter.visibility = INVISIBLE
         }
       }
@@ -230,9 +232,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.menuSleepText.text = ""
-          this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
-          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepText?.text = ""
+          this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText?.visibility = INVISIBLE
           this.menuSleepEndOfChapter.visibility = INVISIBLE
         }
       }
@@ -245,19 +247,19 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
         safelyPerformOperations {
           val remaining = event.remaining
           if (remaining != null) {
-            this.menuSleep.actionView.contentDescription =
+            this.menuSleep.actionView?.contentDescription =
               this.sleepTimerContentDescriptionForTime(event.paused, remaining)
-            this.menuSleepText.text =
+            this.menuSleepText?.text =
               PlayerTimeStrings.minuteSecondTextFromDuration(remaining)
             this.menuSleepEndOfChapter.visibility = INVISIBLE
           } else {
-            this.menuSleep.actionView.contentDescription =
+            this.menuSleep.actionView?.contentDescription =
               this.sleepTimerContentDescriptionEndOfChapter()
-            this.menuSleepText.text = ""
+            this.menuSleepText?.text = ""
             this.menuSleepEndOfChapter.visibility = VISIBLE
           }
 
-          this.menuSleepText.visibility = VISIBLE
+          this.menuSleepText?.visibility = VISIBLE
         }
       }
     )
@@ -319,9 +321,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.menuSleepText.text = ""
-          this.menuSleepText.contentDescription = this.sleepTimerContentDescriptionSetUp()
-          this.menuSleepText.visibility = INVISIBLE
+          this.menuSleepText?.text = ""
+          this.menuSleepText?.contentDescription = this.sleepTimerContentDescriptionSetUp()
+          this.menuSleepText?.visibility = INVISIBLE
           this.menuSleepEndOfChapter.visibility = INVISIBLE
         }
       }
@@ -388,13 +390,13 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       this.menuPlaybackRate.setOnMenuItemClickListener { this.onMenuPlaybackRateSelected(); true }
     }
 
-    this.menuPlaybackRate.actionView.setOnClickListener { this.onMenuPlaybackRateSelected() }
-    this.menuPlaybackRate.actionView.contentDescription =
+    this.menuPlaybackRate.actionView?.setOnClickListener { this.onMenuPlaybackRateSelected() }
+    this.menuPlaybackRate.actionView?.contentDescription =
       this.playbackRateContentDescription()
     this.menuPlaybackRateText =
-      this.menuPlaybackRate.actionView.findViewById(R.id.player_menu_playback_rate_text)
+      this.menuPlaybackRate.actionView?.findViewById(R.id.player_menu_playback_rate_text)
 
-    this.menuPlaybackRateText.text =
+    this.menuPlaybackRateText?.text =
       PlayerPlaybackRateAdapter.textOfRate(this.player.playbackRate)
 
     /*
@@ -423,15 +425,15 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       this.menuSleep.setOnMenuItemClickListener { this.onMenuSleepSelected() }
     }
 
-    this.menuSleep.actionView.setOnClickListener { this.onMenuSleepSelected() }
-    this.menuSleep.actionView.contentDescription = this.sleepTimerContentDescriptionSetUp()
+    this.menuSleep.actionView?.setOnClickListener { this.onMenuSleepSelected() }
+    this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
 
-    this.menuSleepText = this.menuSleep.actionView.findViewById(R.id.player_menu_sleep_text)
-    this.menuSleepText.text = ""
-    this.menuSleepText.visibility = INVISIBLE
+    this.menuSleepText = this.menuSleep.actionView?.findViewById(R.id.player_menu_sleep_text)
+    this.menuSleepText?.text = ""
+    this.menuSleepText?.visibility = INVISIBLE
 
     this.menuSleepEndOfChapter =
-      this.menuSleep.actionView.findViewById(R.id.player_menu_sleep_end_of_chapter)
+      this.menuSleep.actionView!!.findViewById(R.id.player_menu_sleep_end_of_chapter)
     this.menuSleepEndOfChapter.visibility = INVISIBLE
 
     this.menuTOC = this.toolbar.menu.findItem(R.id.player_menu_toc)
@@ -696,8 +698,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       Runnable {
         safelyPerformOperations {
           this.currentPlaybackRate = event.rate
-          this.menuPlaybackRateText.text = PlayerPlaybackRateAdapter.textOfRate(event.rate)
-          this.menuPlaybackRate.actionView.contentDescription =
+          this.menuPlaybackRateText?.text = PlayerPlaybackRateAdapter.textOfRate(event.rate)
+          this.menuPlaybackRate.actionView?.contentDescription =
             this.playbackRateContentDescription()
         }
       }


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 13 (API 33).

Some additional null checks that are now needed have been added.

It also removes the workaround for the failing readium nanohttpd artifact downloads, since the problem has been fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

Different kinds of audiobooks should all play successfully, and the controls and table of contents should all work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested some audiobooks.