### PR TITLE
Added back button to table of contents screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,14 +200,15 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-27T15:31:42+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-11-17T10:57:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
         <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
         <c:change date="2022-09-29T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
         <c:change date="2022-10-03T00:00:00+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
         <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
-        <c:change date="2022-10-27T15:31:42+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-11-17T10:57:16+00:00" summary="Added back button to table of contents screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
@@ -10,6 +10,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -60,12 +61,16 @@ class PlayerTOCFragment : Fragment() {
     state: Bundle?
   ): View {
 
-    val view: RecyclerView =
-      inflater.inflate(R.layout.player_toc_view, container, false) as RecyclerView
+    return inflater.inflate(R.layout.player_toc_view, container, false)
+  }
 
-    view.layoutManager = LinearLayoutManager(view.context)
-    view.setHasFixedSize(true)
-    view.adapter = this.adapter
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    val list = view.findViewById<RecyclerView>(R.id.list)
+    list.layoutManager = LinearLayoutManager(view.context)
+    list.setHasFixedSize(true)
+    list.adapter = this.adapter
 
     /*
      * https://jira.nypl.org/browse/SIMPLY-1152
@@ -77,8 +82,12 @@ class PlayerTOCFragment : Fragment() {
      * turns the animation off.
      */
 
-    (view.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
-    return view
+    (list.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+
+    val toolbar = view.findViewById<Toolbar>(R.id.tocToolbar)
+
+    toolbar.setNavigationOnClickListener { activity?.onBackPressed() }
+    toolbar.setNavigationContentDescription(R.string.audiobook_accessibility_toc_back)
   }
 
   override fun onCreate(state: Bundle?) {

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_view.xml
@@ -1,14 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-<androidx.recyclerview.widget.RecyclerView
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:id="@+id/list"
-  android:name="org.librarysimplified.audiobook.views.PlayerTOCFragment"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  app:layoutManager="LinearLayoutManager"
-  tools:context="org.librarysimplified.audiobook.views.PlayerTOCFragment"
-  tools:listitem="@layout/player_toc_item_view" />
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/tocToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?android:attr/actionBarTheme"
+        app:navigationIcon="@drawable/back" />
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:name="org.librarysimplified.audiobook.views.PlayerTOCFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="LinearLayoutManager"
+        tools:context="org.librarysimplified.audiobook.views.PlayerTOCFragment"
+        tools:listitem="@layout/player_toc_item_view" />
+
+</LinearLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
   <string name="audiobook_accessibility_pause">Pause</string>
   <string name="audiobook_accessibility_book_cover">Book cover</string>
 
+  <string name="audiobook_accessibility_toc_back">Back</string>
+
   <string name="audiobook_accessibility_toc_track_n">Track %1$d</string>
   <string name="audiobook_accessibility_toc_chapter_is_current">Selected</string>
   <string name="audiobook_accessibility_toc_chapter_requires_download">File Must Be Downloaded Before It Can Be Played</string>


### PR DESCRIPTION
**What's this do?**
This PR adds a back button to the TOC screen of an audiobook.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Add-a-Back-button-to-Table-of-Contents-in-Audiobooks-371d32c1254e47d1964130f337f6b204) saying that a back button should be added to the audiobook's TOC screen because there are some devices without the physical button and the user may struggle to return to the previous screen.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Click on the TOC icon at the top right
Confirm [there's a back button](https://user-images.githubusercontent.com/79104027/202431713-b47cf170-7e9a-4de5-81fd-1de264c73d92.png)
Click on it and confirm the app returned to the previous screen

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 