### PR TITLE
Update chapter label on audiobook player

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,7 +200,7 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-11-17T10:57:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-11-23T23:02:11+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
         <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
@@ -208,7 +208,8 @@
         <c:change date="2022-10-03T00:00:00+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
         <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
         <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
-        <c:change date="2022-11-17T10:57:16+00:00" summary="Added back button to table of contents screen."/>
+        <c:change date="2022-11-17T00:00:00+00:00" summary="Added back button to table of contents screen."/>
+        <c:change date="2022-11-23T23:02:11+00:00" summary="Update chapter label on audiobook player."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -1002,16 +1002,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
   }
 
   private fun spineElementText(spineElement: PlayerSpineElementType): String {
-    val title = spineElement.title ?: this.getString(
+    return spineElement.title ?: this.getString(
       R.string.audiobook_player_toc_track_n,
       spineElement.index + 1
-    )
-
-    return this.getString(
-      R.string.audiobook_player_spine_element,
-      title,
-      spineElement.index + 1,
-      spineElement.book.spine.size
     )
   }
 
@@ -1039,13 +1032,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       element.index + 1
     )
 
-    this.playerSpineElement.contentDescription =
-      this.getString(
-        R.string.audiobook_accessibility_chapter_of,
-        accessibilityTitle,
-        element.index + 1,
-        this.book.spine.size
-      )
+    this.playerSpineElement.contentDescription = accessibilityTitle
   }
 
   private fun initializePlayerInfo() {

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -23,8 +23,6 @@
   <string name="audiobook_player_toc_title">Table Of Contents</string>
   <string name="audiobook_player_title">Audio Book Player</string>
 
-  <string name="audiobook_player_spine_element">%1$s (file %2$d of %3$d)</string>
-
   <string name="audiobook_player_sleep_end_of_chapter">End of file</string>
   <string name="audiobook_player_sleep_60">60:00</string>
   <string name="audiobook_player_sleep_45">45:00</string>
@@ -88,8 +86,6 @@
   <string name="audiobook_accessibility_sleep_timer_has_been_set">Sleep timer has been set to</string>
   <string name="audiobook_accessibility_sleep_timer_label">Sleep Timer</string>
   <string name="audiobook_accessibility_sleep_timer_is_paused">The Sleep Timer Is Paused Because Playback Is Paused.</string>
-
-  <string name="audiobook_accessibility_chapter_of">%1$s (file %2$d of %3$d)</string>
 
   <string name="audiobook_accessibility_menu_playback_speed_icon">Set Your Playback Speed</string>
   <string name="audiobook_accessibility_menu_playback_speed_0p75">75 percent</string>


### PR DESCRIPTION
**What's this do?**
This PR updates the chapter title label by removing the "file X of Y" information from it.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Remove-file-X-of-Y-from-audiobook-player-b9f1f4123e90409cb67844f4f8e6cc57) to update the chapter information in order to support the Audible table of contents.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Confirm there's no reference to "file X of Y" on the chapter title label

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 