### PR TITLE
Added phones unplugging handling to pause the audiobook when it happens

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,7 +200,7 @@
         <c:change date="2022-09-07T00:00:00+00:00" summary="Fixed crash on MediaButton receiver."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-11-17T10:57:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
+    <c:release date="2022-11-28T11:00:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.2">
       <c:changes>
         <c:change date="2022-09-26T00:00:00+00:00" summary="Added management of audio coming from different apps."/>
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on player screen."/>
@@ -208,7 +208,8 @@
         <c:change date="2022-10-03T00:00:00+00:00" summary="Updated TOC UI to always display the chapter's duration regardless of the its downloading status."/>
         <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
         <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
-        <c:change date="2022-11-17T10:57:16+00:00" summary="Added back button to table of contents screen."/>
+        <c:change date="2022-11-17T00:00:00+00:00" summary="Added back button to table of contents screen."/>
+        <c:change date="2022-11-28T11:00:38+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerMediaReceiver.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerMediaReceiver.kt
@@ -1,0 +1,15 @@
+package org.librarysimplified.audiobook.views
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+
+class PlayerMediaReceiver(private val onAudioBecomingNoisy: () -> Unit) : BroadcastReceiver() {
+
+  override fun onReceive(context: Context?, intent: Intent?) {
+    if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+      onAudioBecomingNoisy()
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
This PR adds logic to handle what happens when the user unplugs their phones while listening to an audiobook.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket](https://www.notion.so/lyrasis/Android-Audiobooks-from-Biblioboard-Palace-Marketplace-and-Overdrive-continue-to-play-after-wired--57cab4379ea44ec2802c622e330b01ea) saying the audiobook is not being paused when the phones are unplugged, which results in a bad UX.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audioobok
Plug some phones and start listening to the audiobook
Unplug the phones and confirm the audiobook has paused

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 