### PR TITLE
Added ability to open the app when clicking on the audiobook's player notification

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -213,8 +213,10 @@
         <c:change date="2022-11-28T00:00:00+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-08T04:50:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.3">
-      <c:changes/>
+    <c:release date="2023-01-11T18:27:37+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.3">
+      <c:changes>
+        <c:change date="2023-01-11T18:27:37+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=8.0.3-SNAPSHOT
-VERSION_PREVIOUS=8.0.2
+VERSION_PREVIOUS=7.0.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.demo
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
@@ -639,6 +640,14 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
 
   override fun onPlayerNotificationWantsSmallIcon(): Int {
     return R.drawable.icon
+  }
+
+  override fun onPlayerNotificationWantsIntent(): Intent {
+    return Intent(this, ExampleConfigurationActivity::class.java).apply {
+      addCategory(Intent.CATEGORY_LAUNCHER)
+      setAction(Intent.ACTION_MAIN)
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+    }
   }
 
   override fun onPlayerTOCWantsBook(): PlayerAudioBookType {

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.tests.device
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Bundle
@@ -100,6 +101,10 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
 
   override fun onPlayerNotificationWantsSmallIcon(): Int {
     return R.drawable.icon
+  }
+
+  override fun onPlayerNotificationWantsIntent(): Intent {
+    return Intent(this, MockPlayerActivity::class.java)
   }
 
   override fun onPlayerWantsTitle(): String {

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.audiobook.tests.sandbox
 
 import android.app.AlertDialog
+import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Handler
@@ -184,6 +185,10 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
 
   override fun onPlayerNotificationWantsSmallIcon(): Int {
     return R.drawable.icon
+  }
+
+  override fun onPlayerNotificationWantsIntent(): Intent {
+    return Intent(this, SandboxPlayerActivity::class.java)
   }
 
   override fun onPlayerWantsTitle(): String {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -1058,7 +1058,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       bookName = this.listener.onPlayerWantsTitle(),
       isPlaying = false,
       player = this.player,
-      smallIcon = this.listener.onPlayerNotificationWantsSmallIcon()
+      smallIcon = this.listener.onPlayerNotificationWantsSmallIcon(),
+      notificationIntent = this.listener.onPlayerNotificationWantsIntent()
     )
 
     this.listener.onPlayerNotificationWantsBookCover(this::onBookCoverLoaded)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.views
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
@@ -43,6 +44,12 @@ interface PlayerFragmentListenerType {
    */
   @DrawableRes
   fun onPlayerNotificationWantsSmallIcon(): Int
+
+  /**
+   * A fragment requires the intent to be used to open the app from the audiobook player
+   * notification
+   */
+  fun onPlayerNotificationWantsIntent(): Intent
 
   /**
    * A fragment wants to know the title of the audio book being played. The receiver must return

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerInfoModel.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerInfoModel.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.views
 
+import android.content.Intent
 import android.graphics.Bitmap
 import androidx.annotation.DrawableRes
 import org.librarysimplified.audiobook.api.PlayerType
@@ -11,5 +12,6 @@ data class PlayerInfoModel(
   val isPlaying: Boolean,
   val player: PlayerType,
   @DrawableRes
-  val smallIcon: Int
+  val smallIcon: Int,
+  val notificationIntent: Intent
 )

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -140,15 +140,25 @@ class PlayerService : Service() {
         .build()
     )
 
+    val contentIntent = PendingIntent.getActivity(
+      this, 0, playerInfo.notificationIntent,
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
+    )
+
     val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
       .setContentTitle(this.playerInfo.bookName)
       .setContentText(this.playerInfo.bookChapterName)
       .setStyle(
         androidx.media.app.NotificationCompat.MediaStyle()
-          .setShowActionsInCompactView(0,1,2)
+          .setShowActionsInCompactView(0, 1, 2)
           .setShowCancelButton(false)
           .setMediaSession(mediaSession?.sessionToken)
       )
+      .setContentIntent(contentIntent)
       .setSmallIcon(this.playerInfo.smallIcon)
       .setLargeIcon(this.playerInfo.bookCover)
       .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -176,30 +186,30 @@ class PlayerService : Service() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
       when (intent?.action) {
-          ACTION_BACKWARD -> {
-            playerInfo.player.skipBack()
-            updateNotification()
-          }
-          ACTION_FORWARD -> {
-            playerInfo.player.skipForward()
-            updateNotification()
-          }
-          ACTION_PAUSE -> {
-            mediaSession?.isActive = false
-            playerInfo.player.pause()
-            playerInfo = playerInfo.copy(
-              isPlaying = false
-            )
-            updateNotification()
-          }
-          ACTION_PLAY -> {
-            mediaSession?.isActive = true
-            playerInfo.player.play()
-            playerInfo = playerInfo.copy(
-              isPlaying = true
-            )
-            updateNotification()
-          }
+        ACTION_BACKWARD -> {
+          playerInfo.player.skipBack()
+          updateNotification()
+        }
+        ACTION_FORWARD -> {
+          playerInfo.player.skipForward()
+          updateNotification()
+        }
+        ACTION_PAUSE -> {
+          mediaSession?.isActive = false
+          playerInfo.player.pause()
+          playerInfo = playerInfo.copy(
+            isPlaying = false
+          )
+          updateNotification()
+        }
+        ACTION_PLAY -> {
+          mediaSession?.isActive = true
+          playerInfo.player.play()
+          playerInfo = playerInfo.copy(
+            isPlaying = true
+          )
+          updateNotification()
+        }
       }
     }
   }


### PR DESCRIPTION
**What's this do?**
This PR adds a content intent to be added to the audiobook's notification so the user can tap on it and be redirected to the app

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-There-is-no-redirection-to-the-app-from-an-audiobook-playback-screen-in-notification-area-62d04cd1384e438a9fdb5d6bf605288b) saying the current audiobook player notification does nothing when it's clicked and it should redirect the user to the app.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Start playing the audiobook
Send the app to background
Go to the player's notification and click on it
Confirm the [app is reopened](https://user-images.githubusercontent.com/79104027/211889622-d7b23eac-2ac6-4559-87fc-07790b0faf57.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 