### PR TITLE
Added sleep timer to player fragment parameters

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -213,8 +213,10 @@
         <c:change date="2022-11-28T00:00:00+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-08T04:50:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.3">
-      <c:changes/>
+    <c:release date="2023-01-12T11:58:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.3">
+      <c:changes>
+        <c:change date="2023-01-12T11:58:45+00:00" summary="Updated audiobook sleep timer with saved value."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -213,7 +213,7 @@
         <c:change date="2022-11-28T00:00:00+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-12T11:58:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="8.0.3">
+    <c:release date="2023-01-12T11:58:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
       <c:changes>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
         <c:change date="2023-01-12T11:58:45+00:00" summary="Updated audiobook sleep timer with saved value."/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=8.0.3-SNAPSHOT
-VERSION_PREVIOUS=8.0.2
+VERSION_PREVIOUS=7.0.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-audiobook.g
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-audiobook.git
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
-VERSION_NAME=9.0.0
-VERSION_PREVIOUS=8.0.3-SNAPSHOT
+VERSION_NAME=9.0.0-SNAPSHOT
+VERSION_PREVIOUS=8.0.2
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerConfiguration.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerConfiguration.kt
@@ -1,50 +1,52 @@
-package org.librarysimplified.audiobook.views
+package org.librarysimplified.audiobook.api
+
+import org.joda.time.Duration
 
 /**
  * Configuration values for the sleep timer.
  */
 
-enum class PlayerSleepTimerConfiguration {
+enum class PlayerSleepTimerConfiguration(val duration: Duration?) {
 
   /**
    * The sleep timer will finish now. This option is primarily useful for debugging.
    */
 
-  NOW,
+  NOW(Duration.standardSeconds(1L)),
 
   /**
    * The sleep timer will never finish. This is essentially used to switch off the sleep timer.
    */
 
-  OFF,
+  OFF(null),
 
   /**
    * The sleep timer will finish in 15 minutes.
    */
 
-  MINUTES_15,
+  MINUTES_15(Duration.standardMinutes(15L)),
 
   /**
    * The sleep timer will finish in 30 minutes.
    */
 
-  MINUTES_30,
+  MINUTES_30(Duration.standardMinutes(30L)),
 
   /**
    * The sleep timer will finish in 45 minutes.
    */
 
-  MINUTES_45,
+  MINUTES_45(Duration.standardMinutes(45L)),
 
   /**
    * The sleep timer will finish in 60 minutes.
    */
 
-  MINUTES_60,
+  MINUTES_60(Duration.standardMinutes(60L)),
 
   /**
    * The sleep timer will finish at the end of the current chapter.
    */
 
-  END_OF_CHAPTER
+  END_OF_CHAPTER(null)
 }

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -27,6 +27,7 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSleepTimer
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
@@ -685,6 +686,10 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
         fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
       }
     )
+  }
+
+  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+    // do nothing
   }
 
   override fun onPlayerPlaybackRateShouldOpen() {

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -13,6 +13,7 @@ import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.mocking.MockingAudioBook
@@ -163,6 +164,10 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
         )
       fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
     }
+  }
+
+  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+    // do nothing
   }
 
   override fun onPlayerWantsScheduledExecutor(): ScheduledExecutorService {

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -15,6 +15,7 @@ import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.mocking.MockingAudioBook
@@ -255,6 +256,10 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
         fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
       }
     )
+  }
+
+  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+    // do nothing
   }
 
   override fun onPlayerWantsScheduledExecutor(): ScheduledExecutorService {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -524,6 +524,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     this.playerAuthorView.text = this.listener.onPlayerWantsAuthor()
 
     this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
+    if (this.parameters.currentSleepTimer?.duration != null) {
+      this.sleepTimer.start(this.parameters.currentSleepTimer!!.duration)
+    }
 
     initializeService()
   }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import java.util.concurrent.ScheduledExecutorService
@@ -109,6 +110,8 @@ interface PlayerFragmentListenerType {
    */
 
   fun onPlayerSleepTimerShouldOpen()
+
+  fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration)
 
   /**
    * The player wants access to a scheduled executor on which it can submit short time-related

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
@@ -3,6 +3,7 @@ package org.librarysimplified.audiobook.views
 import androidx.annotation.ColorInt
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate.NORMAL_TIME
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import java.io.Serializable
 
 /**
@@ -21,6 +22,7 @@ data class PlayerFragmentParameters(
   )
   @ColorInt val primaryColor: Int? = null,
 
-  val currentRate: PlayerPlaybackRate? = NORMAL_TIME
+  val currentRate: PlayerPlaybackRate? = NORMAL_TIME,
+  val currentSleepTimer: PlayerSleepTimerConfiguration? = PlayerSleepTimerConfiguration.OFF
 
 ) : Serializable

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerAdapter.kt
@@ -7,13 +7,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.END_OF_CHAPTER
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_15
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_30
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_45
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_60
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.NOW
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.OFF
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.END_OF_CHAPTER
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_15
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_30
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_45
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_60
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.NOW
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.OFF
 
 /**
  * A Recycler view adapter used to display and control a sleep timer configuration menu.

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
@@ -9,18 +9,18 @@ import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import org.joda.time.Duration
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilitySleepTimerSettingChanged
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.END_OF_CHAPTER
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_15
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_30
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_45
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.MINUTES_60
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.NOW
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.OFF
-import org.librarysimplified.audiobook.views.PlayerSleepTimerConfiguration.values
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.END_OF_CHAPTER
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_15
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_30
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_45
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.MINUTES_60
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.NOW
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.OFF
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration.values
 import org.slf4j.LoggerFactory
 
 /**
@@ -128,40 +128,17 @@ class PlayerSleepTimerFragment : DialogFragment() {
           PlayerSleepTimerAdapter.hasBeenSetToContentDescriptionOf(resources, item)
         )
       )
+      this.listener.onPlayerSleepTimerUpdated(item)
     } catch (ex: Exception) {
       this.log.debug("ignored exception in event handler: ", ex)
     }
 
-    when (item) {
-      END_OF_CHAPTER -> {
-        this.timer.start(null)
-        this.dismiss()
-      }
-      MINUTES_60 -> {
-        this.timer.start(Duration.standardMinutes(60L))
-        this.dismiss()
-      }
-      MINUTES_45 -> {
-        this.timer.start(Duration.standardMinutes(45L))
-        this.dismiss()
-      }
-      MINUTES_30 -> {
-        this.timer.start(Duration.standardMinutes(30L))
-        this.dismiss()
-      }
-      MINUTES_15 -> {
-        this.timer.start(Duration.standardMinutes(15L))
-        this.dismiss()
-      }
-      NOW -> {
-        this.timer.start(Duration.standardSeconds(1L))
-        this.dismiss()
-      }
-      OFF -> {
-        this.timer.cancel()
-        this.dismiss()
-      }
+    if (item == OFF) {
+      this.timer.cancel()
+    } else {
+      this.timer.start(item.duration)
     }
+    this.dismiss()
   }
 
   companion object {


### PR DESCRIPTION
**What's this do?**
This PR adds a sleep timer configuration to the player fragment parameters. It also updates the location of the existing sleeping timer values so the Palace main module can have access to them.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Audiobook-sleep-timer-not-saved-after-closing-book-bab815834a374893a0588ca96fc8caa7) saying the sleep timer is not being restored when the user sets it and closes and reopens the book.

**How should this be tested? / Do these changes have associated tests?**
_This can only be tested when [this PR](https://github.com/ThePalaceProject/android-core/pull/158) is merged:_

Open the Palace app
Open the any audiobook
Set a sleep timer
Close the audiobook
Reopen the audiobook
Confirm the sleep timer is the same you set

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 