### PR TITLE
Save sleep timer remaining duration

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -213,10 +213,10 @@
         <c:change date="2022-11-28T00:00:00+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-12T11:58:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
+    <c:release date="2023-01-19T10:47:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
       <c:changes>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
-        <c:change date="2023-01-12T11:58:45+00:00" summary="Updated audiobook sleep timer value with missing duration."/>
+        <c:change date="2023-01-19T10:47:24+00:00" summary="Updated audiobook sleep timer value with missing duration."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -216,7 +216,7 @@
     <c:release date="2023-01-12T11:58:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
       <c:changes>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
-        <c:change date="2023-01-12T11:58:45+00:00" summary="Updated audiobook sleep timer with saved value."/>
+        <c:change date="2023-01-12T11:58:45+00:00" summary="Updated audiobook sleep timer value with missing duration."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -216,7 +216,7 @@
     <c:release date="2023-01-19T10:47:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
       <c:changes>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
-        <c:change date="2023-01-19T10:47:24+00:00" summary="Updated audiobook sleep timer value with missing duration."/>
+        <c:change date="2023-01-19T10:47:24+00:00" summary="Updated audiobook sleep timer value with the remaining duration."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -696,7 +696,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     )
   }
 
-  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
+  override fun onPlayerSleepTimerUpdated(remainingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -28,7 +28,6 @@ import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineEleme
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSleepTimer
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
@@ -697,7 +696,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     )
   }
 
-  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -14,7 +14,6 @@ import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.mocking.MockingAudioBook
@@ -171,7 +170,7 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     }
   }
 
-  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -170,7 +170,7 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     }
   }
 
-  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
+  override fun onPlayerSleepTimerUpdated(remainingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -16,7 +16,6 @@ import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.mocking.MockingAudioBook
@@ -263,7 +262,7 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     )
   }
 
-  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -262,7 +262,7 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     )
   }
 
-  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
+  override fun onPlayerSleepTimerUpdated(remainingDuration: Long?) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -230,7 +230,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
 
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
@@ -245,7 +245,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
 
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
@@ -339,7 +339,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
 
           this.menuSleepText?.text = ""
           this.menuSleepText?.contentDescription = this.sleepTimerContentDescriptionSetUp()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -230,6 +230,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
+          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
           this.menuSleepText?.visibility = INVISIBLE
@@ -243,6 +245,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
+          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
           this.menuSleepText?.visibility = INVISIBLE
@@ -257,6 +261,9 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
       Runnable {
         safelyPerformOperations {
           val remaining = event.remaining
+
+          this.listener.onPlayerSleepTimerUpdated(remaining?.millis)
+
           if (remaining != null) {
             this.menuSleep.actionView?.contentDescription =
               this.sleepTimerContentDescriptionForTime(event.paused, remaining)
@@ -332,6 +339,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
+          this.listener.onPlayerSleepTimerUpdated(missingDuration = null)
+
           this.menuSleepText?.text = ""
           this.menuSleepText?.contentDescription = this.sleepTimerContentDescriptionSetUp()
           this.menuSleepText?.visibility = INVISIBLE
@@ -524,8 +533,8 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     this.playerAuthorView.text = this.listener.onPlayerWantsAuthor()
 
     this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
-    if (this.parameters.currentSleepTimer?.duration != null) {
-      this.sleepTimer.start(this.parameters.currentSleepTimer!!.duration)
+    if (this.parameters.currentSleepTimerDuration != null) {
+      this.sleepTimer.start(Duration.millis(this.parameters.currentSleepTimerDuration!!))
     }
 
     initializeService()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerType
 import java.util.concurrent.ScheduledExecutorService
@@ -118,7 +117,12 @@ interface PlayerFragmentListenerType {
 
   fun onPlayerSleepTimerShouldOpen()
 
-  fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration)
+  /**
+   * The user has a sleep timer defined for a given audiobook, and every time the timer's value is
+   * updated, either when setting or when the time goes by, this method is called.
+   */
+
+  fun onPlayerSleepTimerUpdated(missingDuration: Long?)
 
   /**
    * The player wants access to a scheduled executor on which it can submit short time-related

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -122,7 +122,7 @@ interface PlayerFragmentListenerType {
    * updated, either when setting or when the time goes by, this method is called.
    */
 
-  fun onPlayerSleepTimerUpdated(missingDuration: Long?)
+  fun onPlayerSleepTimerUpdated(remainingDuration: Long?)
 
   /**
    * The player wants access to a scheduled executor on which it can submit short time-related

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
@@ -3,7 +3,6 @@ package org.librarysimplified.audiobook.views
 import androidx.annotation.ColorInt
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate.NORMAL_TIME
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import java.io.Serializable
 
 /**
@@ -23,6 +22,6 @@ data class PlayerFragmentParameters(
   @ColorInt val primaryColor: Int? = null,
 
   val currentRate: PlayerPlaybackRate? = NORMAL_TIME,
-  val currentSleepTimer: PlayerSleepTimerConfiguration? = PlayerSleepTimerConfiguration.OFF
+  val currentSleepTimerDuration: Long? = null
 
 ) : Serializable

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
@@ -128,7 +128,7 @@ class PlayerSleepTimerFragment : DialogFragment() {
           PlayerSleepTimerAdapter.hasBeenSetToContentDescriptionOf(resources, item)
         )
       )
-      this.listener.onPlayerSleepTimerUpdated(item)
+      this.listener.onPlayerSleepTimerUpdated(item.duration?.millis)
     } catch (ex: Exception) {
       this.log.debug("ignored exception in event handler: ", ex)
     }


### PR DESCRIPTION
**What's this do?**
This PR updates the existing logic to save the current audio book sleep timer value but it now updates the value every time the timer changes so the app can store the remaining duration for the timer and later restore it instead of restarting the timer.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment in [this ticket](https://www.notion.so/lyrasis/Audiobook-sleep-timer-not-saved-after-closing-book-bab815834a374893a0588ca96fc8caa7) saying the timer shouldn't be restarted when reopening the audiobook but resumed.

**How should this be tested? / Do these changes have associated tests?**
_This can only be tested when [this PR](https://github.com/ThePalaceProject/android-core/pull/160) is merged:_

Open the Palace app
Open any audiobook
Set a timer
Wait a few seconds and close the audiobook
Reopen the audiobook and confirm [the timer is being resumed from where it was paused](https://user-images.githubusercontent.com/79104027/213426722-fbf070f5-18d1-480d-b2e6-0370641152bd.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 