### PR TITLE
Added logic to handle end of chapter timer

### DIFF
--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerConfiguration.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerConfiguration.kt
@@ -18,7 +18,7 @@ enum class PlayerSleepTimerConfiguration(val duration: Duration?) {
    * The sleep timer will never finish. This is essentially used to switch off the sleep timer.
    */
 
-  OFF(null),
+  OFF(Duration.standardSeconds(0L)),
 
   /**
    * The sleep timer will finish in 15 minutes.

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -230,7 +230,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = 0L)
 
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
@@ -245,7 +245,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = 0L)
 
           this.menuSleepText?.text = ""
           this.menuSleep.actionView?.contentDescription = this.sleepTimerContentDescriptionSetUp()
@@ -339,7 +339,7 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     UIThread.runOnUIThread(
       Runnable {
         safelyPerformOperations {
-          this.listener.onPlayerSleepTimerUpdated(remainingDuration = null)
+          this.listener.onPlayerSleepTimerUpdated(remainingDuration = 0L)
 
           this.menuSleepText?.text = ""
           this.menuSleepText?.contentDescription = this.sleepTimerContentDescriptionSetUp()
@@ -533,8 +533,15 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     this.playerAuthorView.text = this.listener.onPlayerWantsAuthor()
 
     this.player.playbackRate = this.parameters.currentRate ?: PlayerPlaybackRate.NORMAL_TIME
+
     if (this.parameters.currentSleepTimerDuration != null) {
-      this.sleepTimer.start(Duration.millis(this.parameters.currentSleepTimerDuration!!))
+      val duration = this.parameters.currentSleepTimerDuration!!
+      if (duration > 0L) {
+        this.sleepTimer.start(Duration.millis(duration))
+      }
+    } else {
+      // if the current duration is null it means the "end of chapter" option was selected
+      this.sleepTimer.start(null)
     }
 
     initializeService()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentParameters.kt
@@ -22,6 +22,6 @@ data class PlayerFragmentParameters(
   @ColorInt val primaryColor: Int? = null,
 
   val currentRate: PlayerPlaybackRate? = NORMAL_TIME,
-  val currentSleepTimerDuration: Long? = null
+  val currentSleepTimerDuration: Long? = 0L
 
 ) : Serializable


### PR DESCRIPTION
**What's this do?**
This PR adds logic to properly handle a "end of chapter" timer. Instead of considering the duration as null for both "Off" and "end of chapter" timers, the first will be set with 0 milliseconds duration, leaving the null value for the latter.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [comment on this PR](https://github.com/ThePalaceProject/android-core/pull/160#pullrequestreview-1271707354) asking if this type of timer was being handled in the added sleep timers feature and, after testing, it wasn't.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any audiobook
Set an "end of file" timer
Close the audiobook and reopen it
Confirm the timer is still set
Set an "off" timer
Close the audiobook and reopen it
Confirm there's no timer

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 