### PR TITLE
Feature/update skipping and rewinding behavior

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -213,10 +213,11 @@
         <c:change date="2022-11-28T00:00:00+00:00" summary="Added phones unplugging handling to pause the audiobook when it happens."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-19T10:47:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
+    <c:release date="2023-02-17T14:10:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.0">
       <c:changes>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
-        <c:change date="2023-01-19T10:47:24+00:00" summary="Updated audiobook sleep timer value with the remaining duration."/>
+        <c:change date="2023-01-19T00:00:00+00:00" summary="Updated audiobook sleep timer value with the remaining duration."/>
+        <c:change date="2023-02-17T14:10:39+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
@@ -63,20 +63,20 @@ interface PlayerType : AutoCloseable {
   fun pause()
 
   /**
-   * Skip to the next chapter.
+   * Skip to the next chapter at the given offset.
    *
    * @throws java.lang.IllegalStateException If and only if the player is closed
    */
 
-  fun skipToNextChapter()
+  fun skipToNextChapter(offset: Long)
 
   /**
-   * Skip to the previous chapter.
+   * Skip to the previous chapter at the given offset.
    *
    * @throws java.lang.IllegalStateException If and only if the player is closed
    */
 
-  fun skipToPreviousChapter()
+  fun skipToPreviousChapter(offset: Long)
 
   /**
    * Skip forwards/backwards, possibly across chapter boundaries. If the given parameter is

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
@@ -408,7 +408,13 @@ class LCPAudioBookPlayer private constructor(
       return SKIP_TO_CHAPTER_NONEXISTENT
     }
 
-    return this.skipToSpineElement(previous, offset, playAutomatically = true)
+    val newOffset = if (previous.duration != null) {
+      previous.duration!!.millis + offset
+    } else {
+      0L
+    }
+
+    return this.skipToSpineElement(previous, newOffset, playAutomatically = true)
   }
 
   private fun skipToSpineElement(
@@ -665,9 +671,14 @@ class LCPAudioBookPlayer private constructor(
 
     assert(milliseconds > 0, { "Milliseconds must be positive" })
 
-    val offset =
-      Math.min(this.exoPlayer.duration, this.exoPlayer.currentPosition + milliseconds)
-    this.seek(offset)
+    val nextMs = this.exoPlayer.currentPosition + milliseconds
+
+    if (nextMs > this.exoPlayer.duration) {
+      val offset = nextMs - this.exoPlayer.duration
+      this.skipToNextChapter(offset)
+    } else {
+      this.seek(nextMs)
+    }
 
     return when (val state = this.stateGet()) {
       LCPPlayerStateInitial,
@@ -688,17 +699,12 @@ class LCPAudioBookPlayer private constructor(
 
     assert(milliseconds < 0, { "Milliseconds must be negative" })
 
-    /*
-     * If the current time is in the range [00:00, 00:04], skipping back should switch
-     * to the previous spine element and then jump 15 seconds back from the end of that
-     * element. Otherwise, it should simply skip backwards, clamping the minimum to 00:00.
-     */
+    val nextMs = this.exoPlayer.currentPosition + milliseconds
 
-    val current = this.exoPlayer.currentPosition
-    if (current <= 4_000L) {
-      this.opSkipToPreviousChapter(milliseconds)
+    if (nextMs < 0) {
+      this.skipToPreviousChapter(nextMs)
     } else {
-      this.seek(Math.max(0L, current + milliseconds))
+      this.seek(nextMs)
     }
 
     return when (val state = this.stateGet()) {
@@ -811,14 +817,14 @@ class LCPAudioBookPlayer private constructor(
     this.engineExecutor.execute { this.opPause() }
   }
 
-  override fun skipToNextChapter() {
+  override fun skipToNextChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToNextChapter(offset = 0) }
+    this.engineExecutor.execute { this.opSkipToNextChapter(offset = offset) }
   }
 
-  override fun skipToPreviousChapter() {
+  override fun skipToPreviousChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToPreviousChapter(offset = 0) }
+    this.engineExecutor.execute { this.opSkipToPreviousChapter(offset = offset) }
   }
 
   override fun skipPlayhead(milliseconds: Long) {

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
@@ -34,6 +34,7 @@ import org.librarysimplified.audiobook.lcp.LCPAudioBookPlayer.LCPPlayerState.LCP
 import org.librarysimplified.audiobook.lcp.LCPAudioBookPlayer.LCPPlayerState.LCPPlayerStateStopped
 import org.librarysimplified.audiobook.lcp.LCPAudioBookPlayer.SkipChapterStatus.SKIP_TO_CHAPTER_NONEXISTENT
 import org.librarysimplified.audiobook.lcp.LCPAudioBookPlayer.SkipChapterStatus.SKIP_TO_CHAPTER_READY
+import org.librarysimplified.audiobook.open_access.ExoAudioBookPlayer
 import org.librarysimplified.audiobook.open_access.ExoBookmarkObserver
 import org.librarysimplified.audiobook.open_access.ExoEngineThread
 import org.readium.r2.shared.publication.asset.FileAsset
@@ -819,12 +820,27 @@ class LCPAudioBookPlayer private constructor(
 
   override fun skipToNextChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToNextChapter(offset = offset) }
+    this.engineExecutor.execute {
+      val status = this.opSkipToNextChapter(offset = offset)
+
+      // if there's no next chapter, the player will go to the end of the chapter
+      if (status == SKIP_TO_CHAPTER_NONEXISTENT) {
+        this.seek(this.exoPlayer.duration)
+      }
+    }
   }
 
   override fun skipToPreviousChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToPreviousChapter(offset = offset) }
+    this.engineExecutor.execute {
+
+      val status = this.opSkipToPreviousChapter(offset = offset)
+
+      // if there's no previous chapter, the player will go to the start of the chapter
+      if (status == SKIP_TO_CHAPTER_NONEXISTENT) {
+        this.seek(0L)
+      }
+    }
   }
 
   override fun skipPlayhead(milliseconds: Long) {

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
@@ -81,12 +81,12 @@ class MockingPlayer(private val book: MockingAudioBook) : PlayerType {
     this.callEvents.onNext("pause")
   }
 
-  override fun skipToNextChapter() {
+  override fun skipToNextChapter(offset: Long) {
     this.log.debug("skipToNextChapter")
     this.callEvents.onNext("skipToNextChapter")
   }
 
-  override fun skipToPreviousChapter() {
+  override fun skipToPreviousChapter(offset: Long) {
     this.log.debug("skipToPreviousChapter")
     this.callEvents.onNext("skipToPreviousChapter")
   }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -806,7 +806,9 @@ class ExoAudioBookPlayer private constructor(
 
     if (nextMs > this.exoPlayer.duration) {
       val offset = nextMs - this.exoPlayer.duration
-      this.skipToNextChapter(offset)
+      this.skipToNextChapter(
+        offset = offset,
+      )
     } else {
       this.seek(nextMs)
     }
@@ -954,12 +956,26 @@ class ExoAudioBookPlayer private constructor(
 
   override fun skipToNextChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToNextChapter(offset = offset) }
+    this.engineExecutor.execute {
+      val status = this.opSkipToNextChapter(offset = offset)
+
+      // if there's no next chapter, the player will go to the end of the chapter
+      if (status == SKIP_TO_CHAPTER_NONEXISTENT) {
+        this.seek(this.exoPlayer.duration)
+      }
+    }
   }
 
   override fun skipToPreviousChapter(offset: Long) {
     this.checkNotClosed()
-    this.engineExecutor.execute { this.opSkipToPreviousChapter(offset = offset) }
+    this.engineExecutor.execute {
+      val status = this.opSkipToPreviousChapter(offset = offset)
+
+      // if there's no previous chapter, the player will go to the start of the chapter
+      if (status == SKIP_TO_CHAPTER_NONEXISTENT) {
+        this.seek(0L)
+      }
+    }
   }
 
   override fun skipPlayhead(milliseconds: Long) {

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
@@ -568,7 +568,7 @@ abstract class ExoEngineProviderContract {
     this.downloadSpineItemAndWait(book.downloadTasks[1])
 
     player.play()
-    player.skipToNextChapter()
+    player.skipToNextChapter(5000L)
     Thread.sleep(10_000L)
 
     player.close()
@@ -634,7 +634,7 @@ abstract class ExoEngineProviderContract {
     Thread.sleep(1000L)
 
     player.playAtLocation(book.spine[1].position)
-    player.skipToPreviousChapter()
+    player.skipToPreviousChapter(5000L)
     Thread.sleep(12_000L)
 
     player.close()


### PR DESCRIPTION
**What's this do?**
This PR adds logic to handle when the user presses the rewind button before the player position reaches the 15 seconds and when the user presses the forward button when there's less than 15 seconds to finish the chapter.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Align-the-Android-behaviour-for-skipping-and-rewinding-for-15-sec-with-the-iOS-behaviour-c6c920c9c3d34dccab4c07541ef5efd5) to update the skipping/rewinding behavior to make it similar to the iOS app.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select any library
Open any audiobook
Start playing it
Wait a few seconds and press the "Rewind" button
Confirm the player moved to the start of the chapter
Wait a few seconds and press the "Forward" button
Confirm the player moved forward 15 seconds
Press the "Rewind" button
Confirm the player moved back 15 seconds
Go to the TOC screen and select the last chapter
Drag the seekbar until less there are less than 15 seconds remaining
Wait a few seconds and press the "Forward" button
Confirm the player moved to the end of the chapter

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 