### PR TITLE
Bugfix/save listening position less frequently

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -223,6 +223,13 @@
     <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
       <c:changes/>
     </c:release>
+    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
+      <c:changes/>
+    </c:release>
+    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.2">
+        <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
+        <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+    </c:release>
   </c:releases>
   <c:ticket-systems>
     <c:ticket-system default="true" id="org.nypl.jira" url="https://jira.nypl.org/browse/"/>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -225,8 +225,6 @@
     </c:release>
     <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
       <c:changes/>
-    </c:release>
-    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.2">
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
     </c:release>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -223,12 +223,9 @@
     <c:release date="2023-03-31T16:58:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-31T16:58:06+00:00" summary="Added support to the new Audible TOC."/>
-      </c:changes>
-    </c:release>
-    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
-      <c:changes/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ git submodule update --remote --recursive
 ```
 
 ```
-$ echo "org.gradle.internal.publish.checksums.insecure=true" >> "$HOME/.gradle/gradle.properties"
+$ echo "systemProp.org.gradle.internal.publish.checksums.insecure=true" >> "$HOME/.gradle/gradle.properties"
 
 $ ./gradlew clean assembleDebug test publishToMavenLocal
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=9.0.1-SNAPSHOT
-VERSION_PREVIOUS=9.0.0
+VERSION_PREVIOUS=8.2.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=9.0.1-SNAPSHOT
-VERSION_PREVIOUS=8.2.0
+VERSION_PREVIOUS=8.0.2
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -27,7 +27,7 @@ class ExoBookmarkObserver private constructor(
   private val logger =
     LoggerFactory.getLogger(ExoBookmarkObserver::class.java)
   private val bookmarkWaitPeriod =
-    Duration.standardSeconds(5L)
+    Duration.standardSeconds(180L)
 
   private var subscription: Subscription
   private var timeAtLast: Instant? = null

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -27,7 +27,7 @@ class ExoBookmarkObserver private constructor(
   private val logger =
     LoggerFactory.getLogger(ExoBookmarkObserver::class.java)
   private val bookmarkWaitPeriod =
-    Duration.standardSeconds(180L)
+    Duration.standardSeconds(15L)
 
   private var subscription: Subscription
   private var timeAtLast: Instant? = null


### PR DESCRIPTION
**What's this do?**
Update polling interval for saving listening position to 15 seconds (formerly 5 seconds).

**Why are we doing this? (w/ JIRA link if applicable)**
Reduce server load
https://www.notion.so/lyrasis/Android-Save-listening-position-less-frequently-ff7c6dc43caa492d98105a48e56d4c26

**How should this be tested? / Do these changes have associated tests?**
Open an audiobook, wait 15 seconds, confirm the bookmark animation appears on the bottom left of the screen. Exit the audiobook and open the same audiobook within the same account on a different device and confirm the bookmark was saved.

**Dependencies for merging? Releasing to production?**
Related to this issue: https://github.com/ThePalaceProject/android-core/pull/173 (not a dependency)

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes (@jdempcy)