### PR TITLE
Updated bookmark saving offset

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -220,11 +220,12 @@
         <c:change date="2023-02-17T00:00:00+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-03-31T16:58:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
+    <c:release date="2023-04-05T17:07:40+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
-        <c:change date="2023-03-31T16:58:06+00:00" summary="Added support to the new Audible TOC."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+        <c:change date="2023-03-31T00:00:00+00:00" summary="Added support to the new Audible TOC."/>
+        <c:change date="2023-04-05T17:07:40+00:00" summary="Updated bookmark saving offset."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -763,7 +763,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
             part = event.spineElement.position.part,
             chapter = event.spineElement.position.chapter,
             startOffset = event.spineElement.position.startOffset,
-            currentOffset = event.offsetMilliseconds
+            currentOffset = event.spineElement.position.startOffset + event.offsetMilliseconds
           )
         )
       }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -85,15 +85,23 @@ class ExoBookmarkObserver private constructor(
       true
     }
 
-    this.onBookmarkCreate(PlayerEventCreateBookmark(event.spineElement,
-      event.spineElement.position.startOffset + event.offsetMilliseconds,
-      isLocalBookmark = true))
+    this.onBookmarkCreate(
+      PlayerEventCreateBookmark(
+        spineElement = event.spineElement,
+        offsetMilliseconds = event.offsetMilliseconds,
+        isLocalBookmark = true
+      )
+    )
 
     if (create) {
       this.timeAtLast = timeNow
-      this.onBookmarkCreate(PlayerEventCreateBookmark(event.spineElement,
-        event.spineElement.position.startOffset + event.offsetMilliseconds,
-        isLocalBookmark = false))
+      this.onBookmarkCreate(
+        PlayerEventCreateBookmark(
+          spineElement = event.spineElement,
+          offsetMilliseconds = event.offsetMilliseconds,
+          isLocalBookmark = false
+        )
+      )
     }
   }
 


### PR DESCRIPTION
**What's this do?**
This PR updates the offset value sent on the event that creates the bookmark

**Why are we doing this? (w/ JIRA link if applicable)**
After reviewing [this PR](https://github.com/ThePalaceProject/android-core/pull/174), @ray-lee found out an inconsistency between the audiobook bookmarks serialization and deserialization methods. Even though they were properly working, it might get confusing because the values handling is not being done in the same place.

**How should this be tested? / Do these changes have associated tests?**
_Local bookmarks_
Open the Palace app
Select "LYRASIS Reads" library
Search for the audiobook "The Martian" by Andy Weir
Play it until a bookmark is saved.
Go back and return to the audiobook.
Confirm the player has been set to the correct position.

_Remote bookmarks_
Using two devices, open the Palace app on both of them
Search for the audiobook "The Martian" by Andy Weir in both of them
Start playing it on device A until a bookmark is set
Close it on device A and open it on device B
Confirm the device B player position is being correctly set.
Start playing it on device B until a bookmark is set
Close it on device B and open it on device A
Confirm the device A player position is being correctly set.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 