### PR TITLE
Fixed track transition on LCP audiobook player

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -220,7 +220,7 @@
         <c:change date="2023-02-17T00:00:00+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-04-27T09:25:42+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
+    <c:release date="2023-05-08T10:02:26+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
@@ -228,7 +228,7 @@
         <c:change date="2023-04-05T00:00:00+00:00" summary="Updated bookmark saving offset."/>
         <c:change date="2023-04-11T00:00:00+00:00" summary="Bluetooth media controls now play/pause and skip tracks."/>
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added audiobook bookmarks."/>
-        <c:change date="2023-04-27T09:25:42+00:00" summary="Fixed bug on LCP player audiobook track transition."/>
+        <c:change date="2023-05-08T10:02:26+00:00" summary="Fixed track transition on LCP audiobook player."/>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
This PR updates the logic that handles the track transition by calculating the current track offset if a chapter is not changed.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a reported bug here saying there are some inconsistency and weird behavior while playing some chapters because the track is changed in the middle of the chapter and not in the end.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Open "Snow Crash" audiobook
Go to chapter 3, around 8:30 and listen for about 30 seconds
Confirm the chapter is correctly played
Navigate some more throught that audiobook and confirm there are no wrong track transitions in the middle of some chapters

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 