### PR TITLE
Bugfix/lock screen audio controls

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -223,6 +223,13 @@
     <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
       <c:changes/>
     </c:release>
+    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
+      <c:changes/>
+    </c:release>
+    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.2">
+        <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
+        <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+    </c:release>
   </c:releases>
   <c:ticket-systems>
     <c:ticket-system default="true" id="org.nypl.jira" url="https://jira.nypl.org/browse/"/>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -225,8 +225,6 @@
     </c:release>
     <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
       <c:changes/>
-    </c:release>
-    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.2">
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
     </c:release>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -223,12 +223,9 @@
     <c:release date="2023-03-31T16:58:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-31T16:58:06+00:00" summary="Added support to the new Audible TOC."/>
-      </c:changes>
-    </c:release>
-    <c:release date="2023-03-14T20:28:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="9.0.1">
-      <c:changes/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -225,6 +225,7 @@
         <c:change date="2023-03-31T16:58:06+00:00" summary="Added support to the new Audible TOC."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
+        <c:change date="2023-04-08T00:00:00+00:00" summary="Always show lock screen audio controls even after they've been dismissed."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ git submodule update --remote --recursive
 ```
 
 ```
-$ echo "org.gradle.internal.publish.checksums.insecure=true" >> "$HOME/.gradle/gradle.properties"
+$ echo "systemProp.org.gradle.internal.publish.checksums.insecure=true" >> "$HOME/.gradle/gradle.properties"
 
 $ ./gradlew clean assembleDebug test publishToMavenLocal
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=9.0.1-SNAPSHOT
-VERSION_PREVIOUS=9.0.0
+VERSION_PREVIOUS=8.2.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-aud
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
 VERSION_NAME=9.0.1-SNAPSHOT
-VERSION_PREVIOUS=8.2.0
+VERSION_PREVIOUS=8.0.2
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -27,7 +27,7 @@ class ExoBookmarkObserver private constructor(
   private val logger =
     LoggerFactory.getLogger(ExoBookmarkObserver::class.java)
   private val bookmarkWaitPeriod =
-    Duration.standardSeconds(5L)
+    Duration.standardSeconds(180L)
 
   private var subscription: Subscription
   private var timeAtLast: Instant? = null

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoBookmarkObserver.kt
@@ -27,7 +27,7 @@ class ExoBookmarkObserver private constructor(
   private val logger =
     LoggerFactory.getLogger(ExoBookmarkObserver::class.java)
   private val bookmarkWaitPeriod =
-    Duration.standardSeconds(180L)
+    Duration.standardSeconds(15L)
 
   private var subscription: Subscription
   private var timeAtLast: Instant? = null

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -793,6 +793,14 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     )
   }
 
+  override fun onResume() {
+    super.onResume()
+    if (this::playerService.isInitialized) {
+      this.playerService.createNotificationChannel()
+      this.playerService.updatePlayerInfo(this.playerInfoModel)
+    }
+  }
+
   override fun onAudioFocusChange(focusChange: Int) {
     when (focusChange) {
       AudioManager.AUDIOFOCUS_GAIN -> {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -13,6 +13,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.util.Log
 import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 
 
 class PlayerService : Service() {
@@ -108,7 +109,8 @@ class PlayerService : Service() {
     super.onDestroy()
   }
 
-  private fun createNotificationChannel() {
+
+  fun createNotificationChannel() {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       val notificationManager =
@@ -126,6 +128,15 @@ class PlayerService : Service() {
 
       notificationManager.createNotificationChannel(notificationChannel)
     }
+
+    val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+      .setOngoing(true)
+      .setContentTitle(NOTIFICATION_CHANNEL_NAME)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+
+    val notification = builder.build()
+    notification.flags = Notification.FLAG_ONGOING_EVENT
+    startForeground(1001, notification)
   }
 
   private fun updateNotification() {
@@ -201,6 +212,7 @@ class PlayerService : Service() {
   inner class PlayerBroadcastReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
+
       when (intent?.action) {
         ACTION_BACKWARD -> {
           playerInfo.player.skipBack()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.util.Log
+import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
 
 
@@ -136,7 +137,13 @@ class PlayerService : Service() {
     mediaSession!!.setCallback(object : MediaSessionCompat.Callback() {
       override fun onMediaButtonEvent(mediaButtonEvent: Intent): Boolean {
         // Handle the media button event here.
-        Log.d("onMediaButtonEvent", "media button event");
+        Log.d("onMediaButtonEvent", mediaButtonEvent.action!!);
+
+        if (Intent.ACTION_MEDIA_BUTTON == mediaButtonEvent.action) {
+          val event: KeyEvent =
+            mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)!!
+          Log.d("onMediaButtonEvent", "KeyCode" + event.getKeyCode())
+        }
         return true
       }
     })

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.IBinder
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
+import android.util.Log
 import androidx.core.app.NotificationCompat
 
 
@@ -131,6 +132,14 @@ class PlayerService : Service() {
     if (mediaSession == null) {
       mediaSession = MediaSessionCompat(this, PlayerService::class.java.simpleName)
     }
+
+    mediaSession!!.setCallback(object : MediaSessionCompat.Callback() {
+      override fun onMediaButtonEvent(mediaButtonEvent: Intent): Boolean {
+        // Handle the media button event here.
+        Log.d("onMediaButtonEvent", "media button event");
+        return true
+      }
+    })
 
     mediaSession?.setMetadata(
       MediaMetadataCompat.Builder()


### PR DESCRIPTION
[EDIT: I will create a new PR as this is showing 13 commits when I am only trying to get 2 commits merged - I will make a new branch off main. So hold off on reviewing this for now!]

**What's this do?**
Always show lock screen audio controls even after being dismissed. 

**Why are we doing this? (w/ JIRA link if applicable)**
Much nicer user experience, following what Spotify and other audio players do.
[Notion ticket here](https://www.notion.so/lyrasis/Lock-screen-controls-do-not-appear-on-Android-13-87fdfcebc86547e8896473bba0f4c02d)

**How should this be tested? / Do these changes have associated tests?**
Play an audiobook. Lock the device (turn off the screen). Turn the screen back on. Notice the audio playback controls are showing on the lock screen. Test that they work as expected. Swipe the playback controls to dismiss them. Unlock the phone. Now lock/unlock the device again (turn the screen off and back on). The playback controls should be there again.

**Dependencies for merging? Releasing to production?**
This needs to be included in android-core.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes