### PR TITLE
Show lock screen audio controls again after they have been dismissed

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -229,6 +229,7 @@
         <c:change date="2023-04-11T00:00:00+00:00" summary="Bluetooth media controls now play/pause and skip tracks."/>
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added audiobook bookmarks."/>
         <c:change date="2023-04-27T09:25:42+00:00" summary="Fixed bug on LCP player audiobook track transition."/>
+        <c:change date="2023-04-08T00:00:00+00:00" summary="Always show lock screen audio controls even after they've been dismissed."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -557,6 +557,14 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     initializeService()
   }
 
+  override fun onResume() {
+    super.onResume()
+    if (this::playerService.isInitialized) {
+      this.playerService.createNotificationChannel()
+      this.playerService.updatePlayerInfo(this.playerInfoModel)
+    }
+  }
+
   private fun handleTouchOnSeekbar(event: MotionEvent?): Boolean {
     when (event?.action) {
       MotionEvent.ACTION_DOWN -> {

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -12,6 +12,7 @@ import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 
 
 class PlayerService : Service() {
@@ -111,7 +112,7 @@ class PlayerService : Service() {
     super.onDestroy()
   }
 
-  private fun createNotificationChannel() {
+  fun createNotificationChannel() {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       val notificationManager =
@@ -129,6 +130,15 @@ class PlayerService : Service() {
 
       notificationManager.createNotificationChannel(notificationChannel)
     }
+
+    val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+      .setOngoing(true)
+      .setContentTitle(NOTIFICATION_CHANNEL_NAME)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+
+    val notification = builder.build()
+    notification.flags = Notification.FLAG_ONGOING_EVENT
+    startForeground(1001, notification)
   }
 
   private fun updateNotification() {


### PR DESCRIPTION
**What's this do?**
Always show lock screen audio controls even after being dismissed. 

**Why are we doing this? (w/ JIRA link if applicable)**
Much nicer user experience, following what Spotify and other audio players do.
[Notion ticket here](https://www.notion.so/lyrasis/Lock-screen-controls-do-not-appear-on-Android-13-87fdfcebc86547e8896473bba0f4c02d)

**How should this be tested? / Do these changes have associated tests?**
Play an audiobook. Lock the device (turn off the screen). Turn the screen back on. Notice the audio playback controls are showing on the lock screen. Test that they work as expected. Swipe the playback controls to dismiss them. Unlock the phone. Now lock/unlock the device again (turn the screen off and back on). The playback controls should be there again.

**Dependencies for merging? Releasing to production?**
This needs to be included in android-core.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes