### PR TITLE
Bugfix/bluetooth audio controls added support

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -230,6 +230,7 @@
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added audiobook bookmarks."/>
         <c:change date="2023-04-27T09:25:42+00:00" summary="Fixed bug on LCP player audiobook track transition."/>
         <c:change date="2023-04-08T00:00:00+00:00" summary="Always show lock screen audio controls even after they've been dismissed."/>
+        <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerService.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.IBinder
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
+import android.util.Log
 import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
 
@@ -25,9 +26,12 @@ class PlayerService : Service() {
     private const val ACTION_PAUSE = "org.librarysimplified.audiobook.views.action_pause"
     private const val ACTION_PLAY = "org.librarysimplified.audiobook.views.action_play"
 
-    private const val KEY_CODE_PLAY_PAUSE = 126
+    private const val KEY_CODE_PLAY = 126
+    private const val KEY_CODE_PAUSE = 127
     private const val KEY_CODE_SKIP_TO_NEXT_CHAPTER = 87
     private const val KEY_CODE_SKIP_TO_PREVIOUS_CHAPTER = 88
+    private const val KEY_CODE_REWIND = 89
+    private const val KEY_CODE_FAST_FORWARD = 90
 
   }
 
@@ -142,18 +146,25 @@ class PlayerService : Service() {
         if (Intent.ACTION_MEDIA_BUTTON == mediaButtonEvent.action) {
           val event: KeyEvent? =
             mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)
-          if (event?.getKeyCode() == KEY_CODE_PLAY_PAUSE) {
+          Log.d("KeyCode", event?.keyCode.toString())
+          if (event?.keyCode == KEY_CODE_PLAY || event?.keyCode == KEY_CODE_PAUSE) {
             if (playerInfo.isPlaying) {
               playerInfo.player.pause()
             } else {
               playerInfo.player.play()
             }
           }
-          else if (event?.getKeyCode() == KEY_CODE_SKIP_TO_NEXT_CHAPTER) {
+          else if (event?.keyCode == KEY_CODE_SKIP_TO_NEXT_CHAPTER) {
             playerInfo.player.skipToNextChapter(0)
           }
-          else if (event?.getKeyCode() == KEY_CODE_SKIP_TO_PREVIOUS_CHAPTER) {
+          else if (event?.keyCode == KEY_CODE_SKIP_TO_PREVIOUS_CHAPTER) {
             playerInfo.player.skipToPreviousChapter(0)
+          }
+          else if (event?.keyCode == KEY_CODE_FAST_FORWARD) {
+            playerInfo.player.skipForward()
+          }
+          else if (event?.keyCode == KEY_CODE_REWIND) {
+            playerInfo.player.skipBack()
           }
         }
         return true


### PR DESCRIPTION
**What's this do?**
Improved support of Bluetooth audio controls. Now we handle both play and pause because some headsets will alternate sending play and pause messages. Either play or pause plays/unpauses, so they do the same thing, which is because some headsets only send play or pause messages. For instance, the Bose headset tested will always send play, so the play message toggles between playing and pause. The Sony headset tested will alternate sending play and pause messages, so those work as expected as well to toggle play and pause.

Additionally, fast forward/rewind are now supported and will seek ahead or behind in 15-second increments for as long as the fast forward/rewind keys are held down (or the touchdown continues in the case of touch events).

**Why are we doing this? (w/ JIRA link if applicable)**
Improved support of more devices to control play/pause with Bluetooth, as well as adding support for fast forward/rewind.
(Notion)[https://www.notion.so/lyrasis/Bluetooth-headphone-controls-don-t-work-158070702bf04351add0451a20023c2a]

**How should this be tested? / Do these changes have associated tests?**
Use as many different Bluetooth headsets or media controls as possible to ensure that audiobooks can play, pause, move to previous track, next track, fast forward, and rewind.

For instance, on the Sony WH-H900N headset you can perform these operations with the following gestures:

Slow double tap (0.4s apart): Play, pause
Swipe forward: next track
Swipe back: start track over, or previous track if already at the beginning of the track
Swipe forward and hold: seek forward (continues to seek in 15s increments while holding)
Swipe back and hold: seek backward (continues to seek in 15s increments while holding)

On other devices there may be hardware buttons or other gestures. But these are the features to test, using whichever devices are available.

**Dependencies for merging? Releasing to production?**
After this is approved, the changelog in android-core will have to be updated, triggering a build that consumes the new version of android-audiobook.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes