### PR TITLE
Added support to manually insert a LCP Passphrase

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -220,7 +220,7 @@
         <c:change date="2023-02-17T00:00:00+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-05-11T11:26:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
+    <c:release date="2023-05-18T14:33:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
@@ -231,7 +231,8 @@
         <c:change date="2023-04-27T00:00:00+00:00" summary="Fixed bug on LCP player audiobook track transition."/>
         <c:change date="2023-04-08T00:00:00+00:00" summary="Always show lock screen audio controls even after they've been dismissed."/>
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
-        <c:change date="2023-05-11T11:26:51+00:00" summary="Fixed track transition on LCP audiobook player."/>
+        <c:change date="2023-05-11T00:00:00+00:00" summary="Fixed track transition on LCP audiobook player."/>
+        <c:change date="2023-05-18T14:33:14+00:00" summary="Added support to manually insert a LCP Passphrase."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioEngineRequest.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioEngineRequest.kt
@@ -50,5 +50,10 @@ data class PlayerAudioEngineRequest(
    * Content protections available to unlock the audio book, if it is protected.
    */
 
-  val contentProtections: List<ContentProtection>? = null
+  val contentProtections: List<ContentProtection>? = null,
+
+  /**
+   * A passphrase, if needed, will be manually inserted.
+   */
+  val manualPassphrase: Boolean = false
 )

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBook.kt
@@ -35,7 +35,8 @@ class LCPAudioBook private constructor(
   override val spineElementDownloadStatus: PublishSubject<PlayerSpineElementDownloadStatus>,
   override val id: PlayerBookID,
   val file: File,
-  val contentProtections: List<ContentProtection>
+  val contentProtections: List<ContentProtection>,
+  val manualPassphrase: Boolean
 ) : PlayerAudioBookType {
 
   private val logger = LoggerFactory.getLogger(LCPAudioBook::class.java)
@@ -47,7 +48,8 @@ class LCPAudioBook private constructor(
     return LCPAudioBookPlayer.create(
       book = this,
       context = this.context,
-      engineExecutor = this.engineExecutor
+      engineExecutor = this.engineExecutor,
+      manualPassphrase = manualPassphrase
     )
   }
 
@@ -82,7 +84,8 @@ class LCPAudioBook private constructor(
       engineExecutor: ScheduledExecutorService,
       manifest: ExoManifest,
       file: File,
-      contentProtections: List<ContentProtection>
+      contentProtections: List<ContentProtection>,
+      manualPassphrase: Boolean
     ): PlayerAudioBookType {
       val bookId = PlayerBookID.transform(manifest.id)
 
@@ -142,7 +145,8 @@ class LCPAudioBook private constructor(
           spineByPartAndChapter = elementsByPart as SortedMap<Int, SortedMap<Int, PlayerSpineElementType>>,
           spineElementDownloadStatus = statusEvents,
           file = file,
-          contentProtections = contentProtections
+          contentProtections = contentProtections,
+          manualPassphrase = manualPassphrase
         )
 
       for (e in elements) {

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
@@ -54,10 +54,13 @@ class LCPAudioBookPlayer private constructor(
 
   companion object {
 
+    private const val TIMEOUT_PLAYER_CREATION = 5L
+
     fun create(
       book: LCPAudioBook,
       context: Context,
       engineExecutor: ScheduledExecutorService,
+      manualPassphrase: Boolean
     ): LCPAudioBookPlayer {
 
       val statusEvents =
@@ -113,7 +116,15 @@ class LCPAudioBookPlayer private constructor(
             statusEvents = statusEvents,
           )
         }
-      ).get(5L, TimeUnit.SECONDS)
+      ).get(
+        // if the manual passphrase is enabled, we need to have an infinite timeout, otherwise the
+        // creation could be interrupted before the user wrote the passphrase
+        if (manualPassphrase) {
+          Long.MAX_VALUE
+        } else {
+          TIMEOUT_PLAYER_CREATION
+        }, TimeUnit.SECONDS
+      )
     }
   }
 

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookProvider.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookProvider.kt
@@ -20,7 +20,8 @@ class LCPAudioBookProvider(
   private val engineExecutor: ScheduledExecutorService,
   private val manifest: PlayerManifest,
   private val file: File,
-  private val contentProtections: List<ContentProtection>
+  private val contentProtections: List<ContentProtection>,
+  private val manualPassphrase: Boolean
 ) : PlayerAudioBookProviderType {
 
   override fun create(
@@ -36,7 +37,8 @@ class LCPAudioBookProvider(
               engineExecutor = this.engineExecutor,
               manifest = parsed.result,
               file = this.file,
-              contentProtections = this.contentProtections
+              contentProtections = this.contentProtections,
+              manualPassphrase = manualPassphrase
             )
           )
         is Failure ->

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPEngineProvider.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPEngineProvider.kt
@@ -62,7 +62,8 @@ class LCPEngineProvider(
       engineExecutor = this.engineExecutor,
       manifest = manifest,
       file = request.file!!,
-      contentProtections = request.contentProtections ?: listOf()
+      contentProtections = request.contentProtections ?: listOf(),
+      manualPassphrase = request.manualPassphrase
     )
   }
 


### PR DESCRIPTION
**What's this do?**
This PR adds support to manually input a LCP passphrase by extending the LCPAudiobookPlayer timeout creation when the manual passphrase is enabled so the user can take their time to input it.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a PR](https://github.com/ThePalaceProject/android-core/pull/186) that adds the manual LCP passphrase feature but we need to handle it on this module because it's responsible of creating a LCP audiobook player.

**How should this be tested? / Do these changes have associated tests?**
Follow the testing steps on [this PR](https://github.com/ThePalaceProject/android-core/pull/186) under the section _"Audiobook"_

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/186) needs to be merged too.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 