### PR TITLE
Added message on bookmarks screen when there are no audiobook bookmarks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -220,7 +220,7 @@
         <c:change date="2023-02-17T00:00:00+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-05-11T11:26:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
+    <c:release date="2023-06-19T09:19:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
@@ -231,7 +231,8 @@
         <c:change date="2023-04-27T00:00:00+00:00" summary="Fixed bug on LCP player audiobook track transition."/>
         <c:change date="2023-04-08T00:00:00+00:00" summary="Always show lock screen audio controls even after they've been dismissed."/>
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
-        <c:change date="2023-05-11T11:26:51+00:00" summary="Fixed track transition on LCP audiobook player."/>
+        <c:change date="2023-05-11T00:00:00+00:00" summary="Fixed track transition on LCP audiobook player."/>
+        <c:change date="2023-06-19T09:19:55+00:00" summary="Added message on bookmarks screen when there are no audiobook bookmarks."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -34,8 +35,9 @@ class PlayerTOCBookmarksFragment : Fragment() {
     }
   }
 
-  private lateinit var listener: PlayerFragmentListenerType
   private lateinit var adapter: PlayerTOCBookmarkAdapter
+  private lateinit var emptyBookmarksText: TextView
+  private lateinit var listener: PlayerFragmentListenerType
   private lateinit var player: PlayerType
 
   override fun onCreateView(
@@ -49,6 +51,12 @@ class PlayerTOCBookmarksFragment : Fragment() {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
+
+    emptyBookmarksText = view.findViewById(R.id.empty_bookmarks_text)
+
+    showOrHideEmptyMessage(
+      show = this.adapter.itemCount == 0
+    )
 
     val list = view.findViewById<RecyclerView>(R.id.list)
     list.layoutManager = LinearLayoutManager(view.context)
@@ -65,7 +73,6 @@ class PlayerTOCBookmarksFragment : Fragment() {
 
       val bookmarks = this.listener.onPlayerTOCWantsBookmarks()
       this.player = this.listener.onPlayerWantsPlayer()
-
       this.adapter = PlayerTOCBookmarkAdapter(
         context = context,
         bookmarks = bookmarks,
@@ -104,6 +111,9 @@ class PlayerTOCBookmarksFragment : Fragment() {
     val bookmarks = this.listener.onPlayerTOCWantsBookmarks()
     this.adapter.setBookmarks(bookmarks)
     this.adapter.notifyItemRemoved(index)
+    showOrHideEmptyMessage(
+      show = bookmarks.isEmpty()
+    )
   }
 
   private fun openBookmarkAndClose(position: PlayerPosition) {
@@ -113,5 +123,13 @@ class PlayerTOCBookmarksFragment : Fragment() {
 
   private fun closeTOC() {
     this.listener.onPlayerTOCWantsClose()
+  }
+
+  private fun showOrHideEmptyMessage(show: Boolean) {
+    emptyBookmarksText.visibility = if (show) {
+      View.VISIBLE
+    } else {
+      View.GONE
+    }
   }
 }

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/fragment_player_toc_chapter_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/fragment_player_toc_chapter_view.xml
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/list"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layoutManager="LinearLayoutManager"
-    tools:context="org.librarysimplified.audiobook.views.toc.PlayerTOCChaptersFragment"
-    tools:listitem="@layout/player_toc_chapter_item_view" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="LinearLayoutManager"
+        tools:context="org.librarysimplified.audiobook.views.toc.PlayerTOCChaptersFragment"
+        tools:listitem="@layout/player_toc_chapter_item_view" />
+
+    <TextView
+        android:id="@+id/empty_bookmarks_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="24dp"
+        android:gravity="center"
+        android:text="@string/audiobook_player_toc_bookmarks_empty"
+        android:textSize="16sp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</FrameLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
   <string name="audiobook_player_toc_menu_stop_confirm_positive">Stop</string>
   <string name="audiobook_player_toc_menu_stop_confirm_negative">Continue</string>
 
+  <string name="audiobook_player_toc_bookmarks_empty">There are no bookmarks for this book</string>
   <string name="audiobook_player_toc_bookmarks_dialog_title_delete">Delete</string>
   <string name="audiobook_player_toc_bookmarks_dialog_message_delete">Are you sure you want to delete this bookmark?</string>
 


### PR DESCRIPTION
**What's this do?**
This PR adds a "no bookmarks" message to the audiobook bookmarks screen when there are no bookmarks

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://ebce-lyrasis.atlassian.net/browse/PP-50) to include this empty bookmarks message in order to make it similar to the iOS version

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Open any audiobook
Start listening to it
Open the TOC and go to "Bookmarks"
Confirm the [empty bookmarks message is displayed](https://github.com/ThePalaceProject/android-audiobook/assets/79104027/3ae28197-ac8d-4686-bc1c-6587cb530c49)
Return and add a bookmark
Go back to the "Bookmarks" page
Confirm the bookmark is displayed and the message is gone
Delete the bookmark and confirm the message is now displayed again

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 