### PR TITLE
Fixed bug of bookmarks list being wrongly updated after deleting a bookmark

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -220,7 +220,7 @@
         <c:change date="2023-02-17T00:00:00+00:00" summary="Updated behaviour for skipping and rewinding an audiobook for 15 seconds."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-06-21T13:41:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
+    <c:release date="2023-07-04T08:27:49+00:00" is-open="true" ticket-system="org.nypl.jira" version="10.0.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Updated polling interval to save reading position in audiobooks to server from 5 seconds to 15 seconds."/>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position to server on play, pause, and stop (which also saves when seeking and changing chapters)."/>
@@ -233,7 +233,8 @@
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
         <c:change date="2023-05-11T00:00:00+00:00" summary="Fixed track transition on LCP audiobook player."/>
         <c:change date="2023-05-18T00:00:00+00:00" summary="Added support to manually insert a LCP Passphrase."/>
-        <c:change date="2023-06-21T13:41:06+00:00" summary="Added message on bookmarks screen when there are no audiobook bookmarks."/>
+        <c:change date="2023-06-21T00:00:00+00:00" summary="Added message on bookmarks screen when there are no audiobook bookmarks."/>
+        <c:change date="2023-07-04T08:27:49+00:00" summary="Added progress bar to indicate a bookmark is being deleted."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-audiobook.g
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-audiobook.git
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
-VERSION_NAME=10.0.1-SNAPSHOT
-VERSION_PREVIOUS=9.0.0
+VERSION_NAME=11.0.0-SNAPSHOT
+VERSION_PREVIOUS=10.0.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerBookmark.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerBookmark.kt
@@ -7,5 +7,6 @@ class PlayerBookmark(
   val date: DateTime,
   val position: PlayerPosition,
   val duration: Long,
-  val uri: URI?
+  val uri: URI?,
+  var isBeingDeleted: Boolean = false
 )

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -4,13 +4,11 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
-import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
-import org.joda.time.DateTime
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
 import org.librarysimplified.audiobook.api.PlayerAudioEngines

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -4,11 +4,13 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
+import org.joda.time.DateTime
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerAudioEngineRequest
 import org.librarysimplified.audiobook.api.PlayerAudioEngines
@@ -638,7 +640,10 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     return emptyList()
   }
 
-  override fun onPlayerShouldDeleteBookmark(bookmark: PlayerBookmark) {
+  override fun onPlayerShouldDeleteBookmark(
+    playerBookmark: PlayerBookmark,
+    onDeleteOperationCompleted: (Boolean) -> Unit
+  ) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -142,7 +142,10 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     return emptyList()
   }
 
-  override fun onPlayerShouldDeleteBookmark(bookmark: PlayerBookmark) {
+  override fun onPlayerShouldDeleteBookmark(
+    playerBookmark: PlayerBookmark,
+    onDeleteOperationCompleted: (Boolean) -> Unit
+  ) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -211,7 +211,10 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     return emptyList()
   }
 
-  override fun onPlayerShouldDeleteBookmark(bookmark: PlayerBookmark) {
+  override fun onPlayerShouldDeleteBookmark(
+    playerBookmark: PlayerBookmark,
+    onDeleteOperationCompleted: (Boolean) -> Unit
+  ) {
     // do nothing
   }
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -101,7 +101,14 @@ interface PlayerFragmentListenerType {
 
   fun onPlayerTOCWantsBookmarks(): List<PlayerBookmark>
 
-  fun onPlayerShouldDeleteBookmark(playerBookmark: PlayerBookmark)
+  /**
+   * The user wants to delete a bookmark.
+   */
+
+  fun onPlayerShouldDeleteBookmark(
+    playerBookmark: PlayerBookmark,
+    onDeleteOperationCompleted: (Boolean) -> Unit
+  )
 
   /**
    * The user has closed the table of contents. The callee should remove the TOC fragment from

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarkAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarkAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.joda.time.Duration
@@ -60,6 +61,25 @@ class PlayerTOCBookmarkAdapter(
     (holder as? BookmarkViewHolder)?.bind(bookmarks[position])
   }
 
+  fun setItemBeingDeleted(beingDeleted: Boolean, position: Int) {
+    setBookmarks(
+      bookmarks.mapIndexed { index, bookmark ->
+        PlayerBookmark(
+          date = bookmark.date,
+          duration = bookmark.duration,
+          isBeingDeleted = if (position == index) {
+            beingDeleted
+          } else {
+            bookmark.isBeingDeleted
+          },
+          position = bookmark.position,
+          uri = bookmark.uri
+        )
+      }
+    )
+    notifyItemChanged(position)
+  }
+
   fun setBookmarks(bookmarksList: List<PlayerBookmark>) {
     bookmarks = bookmarksList
   }
@@ -73,6 +93,8 @@ class PlayerTOCBookmarkAdapter(
       itemView.findViewById(R.id.player_toc_bookmark_item_view_title)
     private val bookmarkDelete: ImageView =
       itemView.findViewById(R.id.player_toc_bookmark_item_view_delete)
+    private val bookmarkLoading: ProgressBar =
+      itemView.findViewById(R.id.player_toc_bookmark_item_view_loading)
 
     private fun contentDescriptionOf(
       title: String,
@@ -117,6 +139,14 @@ class PlayerTOCBookmarkAdapter(
       bookmarkTitle.text = bookmark.position.title.orEmpty()
       bookmarkOffset.text = periodFormatter.print(offset.toPeriod())
       bookmarkDate.text = bookmarkDateStr
+
+      if (bookmark.isBeingDeleted) {
+        bookmarkDelete.visibility = View.GONE
+        bookmarkLoading.visibility = View.VISIBLE
+      } else {
+        bookmarkDelete.visibility = View.VISIBLE
+        bookmarkLoading.visibility = View.GONE
+      }
 
       itemView.contentDescription = contentDescriptionOf(
         title = bookmark.position.title.orEmpty(),

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -83,9 +84,28 @@ class PlayerTOCBookmarksFragment : Fragment() {
           AlertDialog.Builder(context)
             .setMessage(R.string.audiobook_player_toc_bookmarks_dialog_message_delete)
             .setPositiveButton(R.string.audiobook_player_toc_bookmarks_dialog_title_delete) { dialog, _ ->
-              this.listener.onPlayerShouldDeleteBookmark(bookmark)
-              updateBookmarks(index)
               dialog.dismiss()
+              adapter.setItemBeingDeleted(
+                beingDeleted = true,
+                position = index
+              )
+              this.listener.onPlayerShouldDeleteBookmark(
+                playerBookmark = bookmark,
+                onDeleteOperationCompleted = { wasDeleted ->
+                  if (wasDeleted) {
+                    updateBookmarks(index)
+                  } else {
+                    adapter.setItemBeingDeleted(
+                      beingDeleted = false,
+                      position = index
+                    )
+                    Toast.makeText(
+                      requireContext(), R.string.audiobook_player_toc_bookmarks_error_deleting,
+                      Toast.LENGTH_SHORT
+                    ).show()
+                  }
+                }
+              )
             }
             .setNegativeButton(R.string.audiobook_player_options_cancel) { dialog, _ ->
               dialog.dismiss()

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_bookmark_item_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_toc_bookmark_item_view.xml
@@ -7,6 +7,14 @@
     android:orientation="horizontal"
     android:padding="16dp">
 
+    <ProgressBar
+        android:id="@+id/player_toc_bookmark_item_view_loading"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:visibility="gone"
+        android:layout_gravity="center_vertical"
+        tools:visibility="visible" />
+
     <ImageView
         android:id="@+id/player_toc_bookmark_item_view_delete"
         android:layout_width="wrap_content"

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
   <string name="audiobook_player_toc_bookmarks_empty">There are no bookmarks for this book</string>
   <string name="audiobook_player_toc_bookmarks_dialog_title_delete">Delete</string>
   <string name="audiobook_player_toc_bookmarks_dialog_message_delete">Are you sure you want to delete this bookmark?</string>
-  <string name="audiobook_player_toc_bookmarks_error_deleting">There was an error while deleting the bookmark</string>
+  <string name="audiobook_player_toc_bookmarks_error_deleting">There was an error deleting the bookmark</string>
 
 
   <!--

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
   <string name="audiobook_player_toc_bookmarks_empty">There are no bookmarks for this book</string>
   <string name="audiobook_player_toc_bookmarks_dialog_title_delete">Delete</string>
   <string name="audiobook_player_toc_bookmarks_dialog_message_delete">Are you sure you want to delete this bookmark?</string>
+  <string name="audiobook_player_toc_bookmarks_error_deleting">There was an error while deleting the bookmark</string>
 
 
   <!--


### PR DESCRIPTION
**What's this do?**
This PR updates the UI when deleting a bookmark so the user has some feedback about what's happening. This PR also updates the "delete" method so the list can be updated according to the bookmark deletion success or failure.

**Why are we doing this? (w/ JIRA link if applicable)**
As explained in this PR, the bookmarks sometimes failed to be deleted so now we're updating this in order to keep the bookmark as it was in the list if it failed to be deleted, otherwise the user might get a bit confused

**How should this be tested? / Do these changes have associated tests?**
Follow [this PR](https://github.com/ThePalaceProject/android-core/pull/191) steps

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/191) needs to be updated so these changes can be visible

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 