### PR TITLE
Feature/fix sleep timer counting down when audiobook is paused

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -245,8 +245,10 @@
     <c:release date="2023-10-11T00:00:00+00:00" is-open="false" ticket-system="org.palaceproject.jira" version="11.1.0">
       <c:changes/>
     </c:release>
-    <c:release date="2023-10-11T17:25:43+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.1.1">
-      <c:changes/>
+    <c:release date="2023-10-12T12:59:08+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.1.1">
+      <c:changes>
+        <c:change date="2023-10-12T12:59:08+00:00" summary="Fixed player sleep timer counting down when the audiobook is paused."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerType.kt
@@ -15,7 +15,7 @@ import rx.Observable
 interface PlayerSleepTimerType : AutoCloseable {
 
   /**
-   * Start the timer. If a duration is given, the timer will count down over the given duration
+   * Start the timer. If a duration has been given, the timer will count down over the given duration
    * and will periodically publish events giving the remaining time. If no duration is given, the
    * timer will wait indefinitely for a call to {@link #finish()}. If the timer is paused, the
    * timer will be unpaused.
@@ -26,7 +26,18 @@ interface PlayerSleepTimerType : AutoCloseable {
    */
 
   @Throws(java.lang.IllegalStateException::class)
-  fun start(time: Duration?)
+  fun start()
+
+  /**
+   * Sets the duration of the timer.
+   *
+   * @param time The total duration for which the timer will run
+   *
+   * @throws java.lang.IllegalStateException If and only if the player is closed
+   */
+
+  @Throws(java.lang.IllegalStateException::class)
+  fun setDuration(time: Duration?)
 
   /**
    * Cancel the timer. The timer will stop and will publish an event indicating the current
@@ -103,4 +114,6 @@ interface PlayerSleepTimerType : AutoCloseable {
    */
 
   val isRunning: Running?
+
+  val hasCurrentTime: Boolean
 }

--- a/org.librarysimplified.audiobook.demo/build.gradle.kts
+++ b/org.librarysimplified.audiobook.demo/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
     implementation(libs.androidx.viewpager)
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.webkit)
-
+    implementation(libs.google.exoplayer)
     implementation(libs.google.failureaccess)
     implementation(libs.google.guava)
     implementation(libs.google.material)

--- a/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
+++ b/org.librarysimplified.audiobook.demo/src/main/java/org/librarysimplified/audiobook/demo/ExamplePlayerActivity.kt
@@ -608,6 +608,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
               issuerURL = credentials.issuerURL
             )
         }
+
         else -> {
           this.log.debug("no feedbooks extension configuration is necessary")
         }
@@ -700,7 +701,7 @@ class ExamplePlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     ExampleUIThread.runOnUIThread(
       Runnable {
         val fragment =
-          PlayerSleepTimerFragment.newInstance(PlayerFragmentParameters())
+          PlayerSleepTimerFragment.newInstance()
         fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
       }
     )

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSleepTimer.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSleepTimer.kt
@@ -16,8 +16,13 @@ class MockingSleepTimer : PlayerSleepTimerType {
   private var running: PlayerSleepTimerType.Running? = null
   private var closed: Boolean = false
   private var paused: Boolean = false
+  private var time: Duration? = null
 
-  override fun start(time: Duration?) {
+  override fun setDuration(time: Duration?) {
+    this.time = time
+  }
+
+  override fun start() {
     this.running = PlayerSleepTimerType.Running(this.paused, time)
     this.events.onNext(PlayerSleepTimerEvent.PlayerSleepTimerRunning(this.paused, time))
   }
@@ -51,4 +56,7 @@ class MockingSleepTimer : PlayerSleepTimerType {
 
   override val isRunning: PlayerSleepTimerType.Running?
     get() = this.running
+
+  override val hasCurrentTime: Boolean
+    get() = this.time != null
 }

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -325,8 +325,10 @@ class ExoAudioBookPlayer private constructor(
   private fun onDownloadStatusChanged(status: PlayerSpineElementDownloadStatus) {
     ExoEngineThread.checkIsExoEngineThread()
 
-    return when (val currentState = this.stateGet()) {
-      ExoPlayerStateInitial -> Unit
+    when (val currentState = this.stateGet()) {
+      ExoPlayerStateInitial -> {
+        // do nothing
+      }
 
       /*
        * If the we're playing the current spine element, and the status is anything other
@@ -343,9 +345,10 @@ class ExoAudioBookPlayer private constructor(
               this.log.debug("spine element status changed, stopping playback")
               this.playNothing()
             }
-            is PlayerSpineElementDownloaded -> Unit
+            is PlayerSpineElementDownloaded -> {
+              // do nothing
+            }
           }
-        } else {
         }
       }
 
@@ -366,7 +369,6 @@ class ExoAudioBookPlayer private constructor(
             }
             is PlayerSpineElementDownloaded -> Unit
           }
-        } else {
         }
       }
 
@@ -385,10 +387,8 @@ class ExoAudioBookPlayer private constructor(
             is PlayerSpineElementDownloaded -> {
               this.log.debug("spine element status changed, trying to start playback")
               this.playSpineElementIfAvailable(currentState.spineElement, currentState.offset)
-              Unit
             }
           }
-        } else {
         }
       }
     }
@@ -632,10 +632,9 @@ class ExoAudioBookPlayer private constructor(
     ExoEngineThread.checkIsExoEngineThread()
     this.log.debug("opPlay")
 
-    return when (val state = this.stateGet()) {
+    when (val state = this.stateGet()) {
       is ExoPlayerStateInitial -> {
         this.playFirstSpineElementIfAvailable(offset = 0)
-        Unit
       }
 
       is ExoPlayerStatePlaying ->
@@ -646,7 +645,6 @@ class ExoAudioBookPlayer private constructor(
 
       is ExoPlayerStateWaitingForElement -> {
         this.playSpineElementIfAvailable(state.spineElement, offset = state.offset)
-        Unit
       }
     }
   }

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -172,11 +172,7 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
   override fun onPlayerSleepTimerShouldOpen() {
     Handler(Looper.getMainLooper()).post {
       val fragment =
-        PlayerSleepTimerFragment.newInstance(
-          PlayerFragmentParameters(
-            primaryColor = Color.parseColor("#f02020")
-          )
-        )
+        PlayerSleepTimerFragment.newInstance()
       fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
     }
   }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerSleepTimerContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerSleepTimerContract.kt
@@ -66,7 +66,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
@@ -121,7 +122,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
@@ -177,7 +179,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("cancelling timer")
     timer.cancel()
@@ -234,13 +237,15 @@ abstract class PlayerSleepTimerContract {
     }
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(4000L))
+    timer.setDuration(Duration.millis(4000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
 
     logger.debug("restarting timer")
-    timer.start(Duration.millis(6000L))
+    timer.setDuration(Duration.millis(6000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
@@ -288,13 +293,15 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(1000L))
+    timer.setDuration(Duration.millis(1000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(2000L)
 
     logger.debug("restarting timer")
-    timer.start(Duration.millis(1000L))
+    timer.setDuration(Duration.millis(1000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(2000L)
@@ -346,7 +353,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(null)
+    timer.setDuration(null)
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
@@ -406,7 +414,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.standardSeconds(2L))
+    timer.setDuration(Duration.standardSeconds(2L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(500L)
@@ -459,7 +468,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)
@@ -519,7 +529,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     timer.pause()
@@ -588,7 +599,8 @@ abstract class PlayerSleepTimerContract {
     )
 
     logger.debug("starting timer")
-    timer.start(Duration.millis(3000L))
+    timer.setDuration(Duration.millis(3000L))
+    timer.start()
 
     logger.debug("waiting for timer")
     Thread.sleep(1000L)

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -545,11 +545,11 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     if (this.parameters.currentSleepTimerDuration != null) {
       val duration = this.parameters.currentSleepTimerDuration!!
       if (duration > 0L) {
-        this.sleepTimer.start(Duration.millis(duration))
+        this.sleepTimer.setDuration(Duration.millis(duration))
       }
     } else {
       // if the current duration is null it means the "end of chapter" option was selected
-      this.sleepTimer.start(null)
+      this.sleepTimer.setDuration(null)
     }
 
     initializeService()
@@ -874,7 +874,15 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
 
   private fun startPlaying() {
     this.player.play()
-    this.sleepTimer.unpause()
+
+    if (sleepTimer.hasCurrentTime) {
+      if (sleepTimer.isRunning != null) {
+        this.sleepTimer.unpause()
+      } else {
+        this.sleepTimer.start()
+      }
+    }
+
     this.playerInfoModel = this.playerInfoModel.copy(
       isPlaying = true
     )

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerSleepTimerFragment.kt
@@ -40,7 +40,6 @@ class PlayerSleepTimerFragment : DialogFragment() {
   private lateinit var adapter: PlayerSleepTimerAdapter
   private lateinit var timer: PlayerSleepTimerType
   private lateinit var player: PlayerType
-  private lateinit var parameters: PlayerFragmentParameters
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -70,10 +69,6 @@ class PlayerSleepTimerFragment : DialogFragment() {
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
-
-    this.parameters =
-      requireArguments().getSerializable(parametersKey)
-        as PlayerFragmentParameters
 
     if (context is PlayerFragmentListenerType) {
       this.listener = context
@@ -132,26 +127,20 @@ class PlayerSleepTimerFragment : DialogFragment() {
       this.log.debug("ignored exception in event handler: ", ex)
     }
 
-    if (item == OFF) {
-      this.timer.cancel()
-    } else {
-      this.timer.start(item.duration)
+    this.timer.cancel()
+    if (item != OFF) {
+      this.timer.setDuration(item.duration)
+      if (this.player.isPlaying) {
+        this.timer.start()
+      }
     }
     this.dismiss()
   }
 
   companion object {
-
-    const val parametersKey =
-      "org.librarysimplified.audiobook.views.PlayerSleepTimerFragment.parameters"
-
     @JvmStatic
-    fun newInstance(parameters: PlayerFragmentParameters): PlayerSleepTimerFragment {
-      val args = Bundle()
-      args.putSerializable(parametersKey, parameters)
-      val fragment = PlayerSleepTimerFragment()
-      fragment.arguments = args
-      return fragment
+    fun newInstance(): PlayerSleepTimerFragment {
+      return PlayerSleepTimerFragment()
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
This PR adds a separate method to the sleep timer class so the duration can be set without starting the timer. By doing this, we can verify if the player is being played or pause in order to decide if the sleep timer can also be started or just has its duration set. This PR also fixes a bug when a new timer is selected while an old timer was running.
Finally there is also a bug fix a bug on the Demo app and some deleted unused code on the PlayerSleepFragment

**Why are we doing this? (w/ JIRA link if applicable)**
There's a bug report saying the sleep timer starts counting down even when the player is paused

**How should this be tested? / Do these changes have associated tests?**
Open the app
Open any audiobook
Select any sleep timer without playing the audiobook
Confirm the sleep timer doesn't start
Start playing the audiobook
Confirm the sleep timer starts
Close the audiobook and reopen it
Confirm the sleep timer doesn't start
Start playing the audiobook
Confirm the sleep timer starts
Open the sleep timer selection dialog and select a new timer
Confirm the timer is update with the new value

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 