### PR TITLE
Fixed receiver related crashes on Android 13 and Android 14 devices

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -242,7 +242,7 @@
         </c:change>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-06T10:48:02+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.0.1">
+    <c:release date="2023-10-06T00:00:00+00:00" is-open="false" ticket-system="org.palaceproject.jira" version="11.0.1">
       <c:changes>
         <c:change date="2023-10-06T00:00:00+00:00" summary="Use the new Palace theme.">
           <c:tickets>
@@ -250,7 +250,7 @@
             <c:ticket id="PP-533"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-10-06T10:48:02+00:00" summary="Set the skip duration to 30 seconds.">
+        <c:change date="2023-10-06T00:00:00+00:00" summary="Set the skip duration to 30 seconds.">
           <c:tickets>
             <c:ticket id="PP-529"/>
             <c:ticket id="PP-533"/>
@@ -266,8 +266,10 @@
         <c:change date="2023-10-12T00:00:00+00:00" summary="Fixed player sleep timer counting down when the audiobook is paused."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-18T11:17:33+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.2.1">
-      <c:changes/>
+    <c:release date="2023-10-25T13:37:16+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.3.0">
+      <c:changes>
+        <c:change date="2023-10-25T13:37:16+00:00" summary="Fixed receiver related crashes on Android 13 and Android 14 devices."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
+++ b/org.librarysimplified.audiobook.views/src/main/AndroidManifest.xml
@@ -2,11 +2,14 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" android:maxSdkVersion="34" />
+
     <application>
         <service
             android:name="org.librarysimplified.audiobook.views.PlayerService"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
 
         <receiver
             android:name=".PlayerMediaButtonReceiver"

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -3,6 +3,7 @@ package org.librarysimplified.audiobook.views
 import android.content.ComponentName
 import android.content.Context
 import android.content.Context.BIND_AUTO_CREATE
+import android.content.Context.RECEIVER_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
@@ -493,9 +494,13 @@ class PlayerFragment : Fragment(), AudioManager.OnAudioFocusChangeListener {
     this.log.debug("onViewCreated")
     super.onViewCreated(view, state)
 
-    requireActivity().registerReceiver(playerMediaReceiver,
-      IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
-    )
+    val intentFilter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      requireActivity().registerReceiver(playerMediaReceiver, intentFilter, RECEIVER_EXPORTED)
+    } else {
+      requireActivity().registerReceiver(playerMediaReceiver, intentFilter)
+    }
 
     this.toolbar = view.findViewById(R.id.audioBookToolbar)
     this.toolbar.setNavigationContentDescription(R.string.audiobook_accessibility_navigation_back)


### PR DESCRIPTION
**What's this do?**
This PR fixes some receiver/service related issues on Android 13 and 14 devices.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a crash with some occurrences on Crashlytics](https://ebce-lyrasis.atlassian.net/browse/PP-634) when playing an audiobook.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app on an Android 13 or Android 14 device
Open any audiobook
Confirm the app doesn't crash
Start playing the audiobook
Go to the notification commands and press pause/play and the rewind/forward buttons
Confirm everything's working correctly

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 