### PR TITLE
PP-649: Stop using the legacy alert dialog

### DIFF
--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCBookmarksFragment.kt
@@ -1,6 +1,5 @@
 package org.librarysimplified.audiobook.views.toc
 
-import android.app.AlertDialog
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -12,6 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerFragmentListenerType
@@ -80,7 +80,7 @@ class PlayerTOCBookmarksFragment : Fragment() {
           openBookmarkAndClose(bookmarkPosition)
         },
         onDelete = { index, bookmark ->
-          AlertDialog.Builder(context)
+          MaterialAlertDialogBuilder(context)
             .setMessage(R.string.audiobook_player_toc_bookmarks_dialog_message_delete)
             .setPositiveButton(R.string.audiobook_player_toc_bookmarks_dialog_title_delete) { dialog, _ ->
               dialog.dismiss()

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCChapterAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCChapterAdapter.kt
@@ -1,6 +1,5 @@
 package org.librarysimplified.audiobook.views.toc
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.content.res.Resources
@@ -13,6 +12,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormatter
 import org.joda.time.format.PeriodFormatterBuilder
@@ -283,7 +283,7 @@ class PlayerTOCChapterAdapter(
 
   private fun onConfirmCancelDownloading(item: PlayerSpineElementType) {
     val dialog =
-      AlertDialog.Builder(this.context)
+      MaterialAlertDialogBuilder(this.context)
         .setCancelable(true)
         .setMessage(R.string.audiobook_part_download_stop_confirm)
         .setPositiveButton(

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCChaptersFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/toc/PlayerTOCChaptersFragment.kt
@@ -1,6 +1,5 @@
 package org.librarysimplified.audiobook.views.toc
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
@@ -11,6 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
@@ -143,7 +143,7 @@ class PlayerTOCChaptersFragment : Fragment(), PlayerTOCInnerFragment {
     this.log.debug("onMenuStopAllSelected")
 
     val dialog =
-      AlertDialog.Builder(this.context)
+      MaterialAlertDialogBuilder(this.requireContext())
         .setCancelable(true)
         .setMessage(R.string.audiobook_player_toc_menu_stop_all_confirm)
         .setPositiveButton(


### PR DESCRIPTION
**What's this do?**
The legacy alert dialog doesn't play nicely with the Material 3 theme.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-649

**How should this be tested? / Do these changes have associated tests?**
Check that the buttons in the confirmation dialog are visible on night mode when trying to delete bookmarks.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried it.