### PR TITLE
PP-737: Fix a crash when the track index is -1

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -291,8 +291,14 @@
         <c:change date="2023-11-15T00:00:00+00:00" summary="Correct some possible lifecycle issues."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-11-15T12:20:46+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.5.1">
-      <c:changes/>
+    <c:release date="2023-11-20T11:26:13+00:00" is-open="true" ticket-system="org.palaceproject.jira" version="11.5.1">
+      <c:changes>
+        <c:change date="2023-11-20T11:26:13+00:00" summary="Fix an LCP audio book crash.">
+          <c:tickets>
+            <c:ticket id="PP-737"/>
+          </c:tickets>
+        </c:change>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-audiobook.g
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-audiobook.git
 POM_SCM_URL=https://github.com/ThePalaceProject/android-audiobook
 POM_URL=https://github.com/ThePalaceProject/android-audiobook
-VERSION_NAME=11.5.1-SNAPSHOT
+VERSION_NAME=11.6.0-SNAPSHOT
 VERSION_PREVIOUS=11.5.0
 
 android.useAndroidX=true

--- a/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.lcp/src/main/java/org/librarysimplified/audiobook/lcp/LCPAudioBookPlayer.kt
@@ -168,7 +168,8 @@ class LCPAudioBookPlayer private constructor(
     it.itemManifest.originalLink
   }.distinct()
 
-  private var trackIndex = -1
+  @Volatile
+  private var currentTrackIndex: Int? = null
 
   private val exoPlayerEventListener = object : ExoPlayer.Listener {
     override fun onPlayerError(error: ExoPlaybackException?) {
@@ -760,8 +761,8 @@ class LCPAudioBookPlayer private constructor(
     }
   }
 
-  private fun preparePlayer(playAutomatically: Boolean) {
-    val trackToPlay = tracksToPlay[trackIndex]
+  private fun preparePlayer(playAutomatically: Boolean, newTrackIndex: Int) {
+    val trackToPlay = tracksToPlay[newTrackIndex]
 
     this.log.debug("preparePlayer: {} (offset {})", trackToPlay.title, trackPlaybackOffset)
 
@@ -882,10 +883,16 @@ class LCPAudioBookPlayer private constructor(
       offset = offset
     )
 
-    if (trackIndex != newIndex) {
-      trackIndex = newIndex
+    if (newIndex == -1) {
+      this.log.debug("there's no track to play")
+      return
+    }
+
+    if (currentTrackIndex != newIndex) {
+      currentTrackIndex = newIndex
       preparePlayer(
-        playAutomatically = playAutomatically
+        playAutomatically = playAutomatically,
+        newTrackIndex = newIndex
       )
     }
 


### PR DESCRIPTION
**What's this do?**
This fixes a crash that can be triggered by trying to seek to an out-of-range chapter (which will result in a track index of `-1` being returned and then passed to the player).

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-737

**How should this be tested? / Do these changes have associated tests?**
Open an LCP audio book and then press the "seek back 30 seconds button". The app shouldn't crash.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tried it